### PR TITLE
Handle approved DePix deposits and update later depix_sent details

### DIFF
--- a/BTCPayServer.Plugins.Depix.Tests/DepixStatusTests.cs
+++ b/BTCPayServer.Plugins.Depix.Tests/DepixStatusTests.cs
@@ -1,0 +1,48 @@
+using BTCPayServer.Client.Models;
+using BTCPayServer.Plugins.Depix.Data.Enums;
+using BTCPayServer.Services.Invoices;
+using Xunit;
+
+namespace BTCPayServer.Plugins.Depix.Tests;
+
+public class DepixStatusTests
+{
+    [Theory]
+    [InlineData("approved", DepixStatus.Approved)]
+    [InlineData("APPROVED", DepixStatus.Approved)]
+    [InlineData("DEPIX-SENT", DepixStatus.DepixSent)]
+    public void TryParseRecognizesKnownDepositStatuses(string value, DepixStatus expected)
+    {
+        Assert.True(DepixStatusExtensions.TryParse(value, out var status));
+        Assert.Equal(expected, status);
+        Assert.DoesNotContain('-', status.ToApiString());
+    }
+
+    [Fact]
+    public void ApprovedSettlesInvoice()
+    {
+        var state = DepixStatus.Approved.ToInvoiceState(new InvoiceState(InvoiceStatus.New, InvoiceExceptionStatus.None));
+
+        Assert.NotNull(state);
+        Assert.Equal(InvoiceStatus.Settled, state!.Status);
+        Assert.Equal(InvoiceExceptionStatus.None, state.ExceptionStatus);
+    }
+
+    [Theory]
+    [InlineData(DepixStatus.Approved, true)]
+    [InlineData(DepixStatus.DepixSent, true)]
+    [InlineData(DepixStatus.UnderReview, false)]
+    public void OnlyApprovedAndDepixSentAreConfirmedPaymentStatuses(DepixStatus status, bool expected)
+    {
+        Assert.Equal(expected, status.IsConfirmedPaymentStatus());
+    }
+
+    [Theory]
+    [InlineData(DepixStatus.Approved, "depix_sent", false)]
+    [InlineData(DepixStatus.DepixSent, "approved", true)]
+    [InlineData(DepixStatus.Approved, "refunded", false)]
+    public void StatusPrecedencePreventsDowngrades(DepixStatus incoming, string current, bool expected)
+    {
+        Assert.Equal(expected, incoming.ShouldReplace(current));
+    }
+}

--- a/BTCPayServer.Plugins.Depix.Tests/DepixWebhookServiceTests.cs
+++ b/BTCPayServer.Plugins.Depix.Tests/DepixWebhookServiceTests.cs
@@ -1,0 +1,288 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer;
+using BTCPayServer.Client.Models;
+using BTCPayServer.Data;
+using BTCPayServer.Events;
+using BTCPayServer.Logging;
+using BTCPayServer.Payments;
+using BTCPayServer.Plugins.Depix.Data.Models;
+using BTCPayServer.Plugins.Depix.PaymentHandlers;
+using BTCPayServer.Plugins.Depix.Services;
+using BTCPayServer.Rating;
+using BTCPayServer.Services.Invoices;
+using BTCPayServer.Services.Stores;
+using BTCPayServer.Tests;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace BTCPayServer.Plugins.Depix.Tests;
+
+[Collection(SharedPluginTestCollection.CollectionName)]
+public sealed class DepixWebhookServiceTests : IAsyncLifetime
+{
+    private static readonly PaymentMethodId PixPmid = new("PIX");
+    private readonly UnitTestBase _unitTestBase;
+    private ServerTester _server = null!;
+
+    public DepixWebhookServiceTests(SharedPluginTestFixture fixture, ITestOutputHelper output)
+    {
+        _ = fixture;
+        _unitTestBase = new UnitTestBase(output);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _server = _unitTestBase.CreateServerTester(scope: CreateScopePath(), newDb: true);
+        await _server.StartAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        _server.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact(Timeout = TestUtils.TestTimeout)]
+    public async Task ApprovedWebhookCreatesPaymentAndDepixSentUpdatesExistingPayment()
+    {
+        var storeId = await CreateStoreAsync();
+        var invoice = await CreatePixInvoiceAsync(storeId, qrId: "qr-approved-1", valueInCents: 1234);
+        var service = _server.PayTester.GetService<DepixService>();
+        var events = _server.PayTester.GetService<EventAggregator>();
+        var receivedPaymentEvents = new List<InvoiceEvent>();
+        var needUpdateEvents = new List<InvoiceNeedUpdateEvent>();
+        var dataChangedEvents = new List<InvoiceDataChangedEvent>();
+        using var receivedPaymentSubscription = events.Subscribe<InvoiceEvent>(evt =>
+        {
+            if (evt.InvoiceId == invoice.Id && evt.Name == InvoiceEvent.ReceivedPayment)
+                receivedPaymentEvents.Add(evt);
+        });
+        using var needUpdateSubscription = events.Subscribe<InvoiceNeedUpdateEvent>(evt =>
+        {
+            if (evt.InvoiceId == invoice.Id)
+                needUpdateEvents.Add(evt);
+        });
+        using var dataChangedSubscription = events.Subscribe<InvoiceDataChangedEvent>(evt =>
+        {
+            if (evt.InvoiceId == invoice.Id)
+                dataChangedEvents.Add(evt);
+        });
+
+        await service.ProcessWebhookAsync(storeId, new DepositWebhookBody
+        {
+            QrId = "qr-approved-1",
+            Status = "approved",
+            ValueInCents = 1234,
+            PayerName = "Alice"
+        }, CancellationToken.None);
+
+        var approvedPayment = await GetPixPaymentAsync(invoice.Id);
+        Assert.Equal(PaymentStatus.Settled, approvedPayment.Status);
+        var receivedPaymentEvent = Assert.Single(receivedPaymentEvents);
+        Assert.Equal(approvedPayment.Id, receivedPaymentEvent.Payment.Id);
+        var approvedDetails = GetPixPaymentDetails(approvedPayment);
+        Assert.Equal("approved", approvedDetails.Status);
+        Assert.Equal("Alice", approvedDetails.PayerName);
+
+        await service.ProcessWebhookAsync(storeId, new DepositWebhookBody
+        {
+            QrId = "qr-approved-1",
+            Status = "depix_sent",
+            ValueInCents = 1234,
+            BlockchainTxId = "liquid-tx-1"
+        }, CancellationToken.None);
+
+        var invoiceAfterDepixSent = await _server.PayTester.InvoiceRepository.GetInvoice(invoice.Id);
+        var payments = invoiceAfterDepixSent.GetPayments(false).Where(p => p.PaymentMethodId == PixPmid).ToList();
+        var updatedPayment = Assert.Single(payments);
+        var updatedDetails = GetPixPaymentDetails(updatedPayment);
+        Assert.Equal("depix_sent", updatedDetails.Status);
+        Assert.Equal("liquid-tx-1", updatedDetails.BlockchainTxId);
+        Assert.Equal("Alice", updatedDetails.PayerName);
+        Assert.Equal("depix_sent", (await GetPixPromptDetailsAsync(invoice.Id)).Status);
+        Assert.Contains(needUpdateEvents, evt => evt.InvoiceId == invoice.Id);
+        Assert.Contains(dataChangedEvents, evt => evt.InvoiceId == invoice.Id);
+    }
+
+    [Fact(Timeout = TestUtils.TestTimeout)]
+    public async Task ApprovedAfterDepixSentDoesNotDowngradeStoredStatus()
+    {
+        var storeId = await CreateStoreAsync();
+        var invoice = await CreatePixInvoiceAsync(storeId, qrId: "qr-out-of-order", valueInCents: 1234);
+        var service = _server.PayTester.GetService<DepixService>();
+
+        await service.ProcessWebhookAsync(storeId, new DepositWebhookBody
+        {
+            QrId = "qr-out-of-order",
+            Status = "depix_sent",
+            ValueInCents = 1234,
+            BlockchainTxId = "liquid-tx-1"
+        }, CancellationToken.None);
+
+        await service.ProcessWebhookAsync(storeId, new DepositWebhookBody
+        {
+            QrId = "qr-out-of-order",
+            Status = "approved",
+            ValueInCents = 1234,
+            BankTxId = "bank-tx-late",
+            PayerName = "Late payer"
+        }, CancellationToken.None);
+
+        var invoiceAfterApproved = await _server.PayTester.InvoiceRepository.GetInvoice(invoice.Id);
+        var payment = Assert.Single(invoiceAfterApproved.GetPayments(false), p => p.PaymentMethodId == PixPmid);
+        var details = GetPixPaymentDetails(payment);
+        Assert.Equal("depix_sent", details.Status);
+        Assert.Equal("liquid-tx-1", details.BlockchainTxId);
+        Assert.Equal("bank-tx-late", details.BankTxId);
+        Assert.Equal("Late payer", details.PayerName);
+
+        var promptDetails = await GetPixPromptDetailsAsync(invoice.Id);
+        Assert.Equal("depix_sent", promptDetails.Status);
+        Assert.Equal("Late payer", promptDetails.Payer?.Name);
+    }
+
+    [Fact(Timeout = TestUtils.TestTimeout)]
+    public async Task DuplicateWebhookWithMismatchedAmountDoesNotChangeStoredAmount()
+    {
+        var storeId = await CreateStoreAsync();
+        var invoice = await CreatePixInvoiceAsync(storeId, qrId: "qr-amount-mismatch", valueInCents: 1234);
+        var service = _server.PayTester.GetService<DepixService>();
+
+        await service.ProcessWebhookAsync(storeId, new DepositWebhookBody
+        {
+            QrId = "qr-amount-mismatch",
+            Status = "approved",
+            ValueInCents = 1234,
+            PayerName = "Alice"
+        }, CancellationToken.None);
+
+        await service.ProcessWebhookAsync(storeId, new DepositWebhookBody
+        {
+            QrId = "qr-amount-mismatch",
+            Status = "depix_sent",
+            ValueInCents = 9999,
+            BlockchainTxId = "liquid-tx-mismatch"
+        }, CancellationToken.None);
+
+        var invoiceAfterMismatch = await _server.PayTester.InvoiceRepository.GetInvoice(invoice.Id);
+        var payment = Assert.Single(invoiceAfterMismatch.GetPayments(false), p => p.PaymentMethodId == PixPmid);
+        var details = GetPixPaymentDetails(payment);
+        Assert.Equal(12.34m, payment.Value);
+        Assert.Equal("depix_sent", details.Status);
+        Assert.Equal(1234, details.ValueInCents);
+        Assert.Equal("liquid-tx-mismatch", details.BlockchainTxId);
+        Assert.Equal("Alice", details.PayerName);
+
+        var promptDetails = await GetPixPromptDetailsAsync(invoice.Id);
+        Assert.Equal("depix_sent", promptDetails.Status);
+        Assert.Equal(1234, promptDetails.ValueInCents);
+    }
+
+    [Fact(Timeout = TestUtils.TestTimeout)]
+    public async Task FirstConfirmedWebhookWithMismatchedAmountUsesPromptAmount()
+    {
+        var storeId = await CreateStoreAsync();
+        var invoice = await CreatePixInvoiceAsync(storeId, qrId: "qr-first-amount-mismatch", valueInCents: 1234);
+        var service = _server.PayTester.GetService<DepixService>();
+
+        await service.ProcessWebhookAsync(storeId, new DepositWebhookBody
+        {
+            QrId = "qr-first-amount-mismatch",
+            Status = "approved",
+            ValueInCents = 9999,
+            PayerName = "Alice"
+        }, CancellationToken.None);
+
+        var payment = await GetPixPaymentAsync(invoice.Id);
+        Assert.Equal(12.34m, payment.Value);
+        var details = GetPixPaymentDetails(payment);
+        Assert.Equal("approved", details.Status);
+        Assert.Null(details.ValueInCents);
+        Assert.Equal("Alice", details.PayerName);
+
+        var promptDetails = await GetPixPromptDetailsAsync(invoice.Id);
+        Assert.Equal("approved", promptDetails.Status);
+        Assert.Equal(1234, promptDetails.ValueInCents);
+    }
+
+    private async Task<string> CreateStoreAsync()
+    {
+        var account = _server.NewAccount();
+        await account.RegisterAsync(isAdmin: true);
+        await account.CreateStoreAsync();
+        return account.StoreId;
+    }
+
+    private async Task<InvoiceEntity> CreatePixInvoiceAsync(
+        string storeId,
+        string qrId,
+        int valueInCents)
+    {
+        var storeRepository = _server.PayTester.GetService<StoreRepository>();
+        var handlers = _server.PayTester.GetService<PaymentMethodHandlerDictionary>();
+        var handler = handlers[PixPmid];
+        var invoiceRepository = _server.PayTester.InvoiceRepository;
+        var store = await storeRepository.FindStore(storeId) ?? throw new InvalidOperationException("Store not found.");
+
+        var invoice = invoiceRepository.CreateNewInvoice(storeId);
+        invoice.Currency = "BRL";
+        invoice.Price = valueInCents / 100m;
+        invoice.AddRate(new CurrencyPair("BRL", "BRL"), 1m);
+        var details = new DePixPaymentMethodDetails
+        {
+            QrId = qrId,
+            Status = "pending",
+            ValueInCents = valueInCents
+        };
+
+        invoice.SetPaymentPrompt(PixPmid, new PaymentPrompt
+        {
+            Currency = "BRL",
+            Divisibility = 2,
+            Destination = "https://example.invalid/pix.png",
+            Details = JToken.FromObject(details, handler.Serializer)
+        });
+
+        await invoiceRepository.CreateInvoiceAsync(new InvoiceCreationContext(
+            store,
+            store.GetStoreBlob(),
+            invoice,
+            new InvoiceLogs(),
+            handlers,
+            invoicePaymentMethodFilter: null));
+
+        return invoice;
+    }
+
+    private async Task<PaymentEntity> GetPixPaymentAsync(string invoiceId)
+    {
+        var invoice = await _server.PayTester.InvoiceRepository.GetInvoice(invoiceId);
+        return Assert.Single(invoice.GetPayments(false), p => p.PaymentMethodId == PixPmid);
+    }
+
+    private DePixPaymentData GetPixPaymentDetails(PaymentEntity payment)
+    {
+        var handler = _server.PayTester.GetService<PaymentMethodHandlerDictionary>()[PixPmid];
+        return payment.GetDetails<DePixPaymentData>(handler) ?? throw new InvalidOperationException("Missing Pix payment details.");
+    }
+
+    private async Task<DePixPaymentMethodDetails> GetPixPromptDetailsAsync(string invoiceId)
+    {
+        var invoice = await _server.PayTester.InvoiceRepository.GetInvoice(invoiceId);
+        var prompt = invoice.GetPaymentPrompt(PixPmid) ?? throw new InvalidOperationException("Missing Pix prompt.");
+        var handler = _server.PayTester.GetService<PaymentMethodHandlerDictionary>()[PixPmid];
+        return handler.ParsePaymentPromptDetails(prompt.Details) as DePixPaymentMethodDetails ??
+               throw new InvalidOperationException("Missing Pix prompt details.");
+    }
+
+    private static string CreateScopePath()
+    {
+        return Path.Combine(Path.GetTempPath(), "depix-webhook-service", Guid.NewGuid().ToString("N"));
+    }
+}

--- a/BTCPayServer.Plugins.Depix.Tests/PixPaymentMethodHandlerTests.cs
+++ b/BTCPayServer.Plugins.Depix.Tests/PixPaymentMethodHandlerTests.cs
@@ -1,0 +1,81 @@
+using System.Threading.Tasks;
+using BTCPayServer.Client.Models;
+using BTCPayServer.Data;
+using BTCPayServer.Logging;
+using BTCPayServer.Payments;
+using BTCPayServer.Plugins.Depix.Data.Models;
+using BTCPayServer.Plugins.Depix.PaymentHandlers;
+using BTCPayServer.Plugins.Depix.Services;
+using BTCPayServer.Services.Invoices;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace BTCPayServer.Plugins.Depix.Tests;
+
+public class PixPaymentMethodHandlerTests
+{
+    private static readonly PaymentMethodId PixPmid = new("PIX");
+
+    [Fact]
+    public void ApplyPromptDetailsPersistsQrAmountValueInCents()
+    {
+        var handler = new TestPixHandler();
+        var invoice = new InvoiceEntity
+        {
+            Id = "invoice-prompt-details",
+            Currency = "BRL",
+            Price = 12.34m,
+            Status = InvoiceStatus.New
+        };
+        var context = new PaymentMethodContext(
+            new BTCPayServer.Data.StoreData { Id = "store-prompt-details" },
+            new StoreBlob(),
+            new JObject(),
+            handler,
+            invoice,
+            new InvoiceLogs());
+        var service = new DepixService(null!, null!, null!, null!, null!, null!, null!, null!, null!);
+
+        service.ApplyPromptDetails(
+            context,
+            new DepixDepositResponse("qr-prompt-details", "https://example.invalid/qr.png", "copy-paste"),
+            "depix-address",
+            1234);
+
+        var details = Assert.IsType<DePixPaymentMethodDetails>(handler.ParsePaymentPromptDetails(context.Prompt.Details));
+        Assert.Equal("qr-prompt-details", details.QrId);
+        Assert.Equal(1234, details.ValueInCents);
+    }
+
+    private sealed class TestPixHandler : IPaymentMethodHandler
+    {
+        public PaymentMethodId PaymentMethodId => PixPmid;
+        public JsonSerializer Serializer { get; } = BlobSerializer.CreateSerializer().Serializer;
+
+        public Task ConfigurePrompt(PaymentMethodContext context)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task BeforeFetchingRates(PaymentMethodContext context)
+        {
+            return Task.CompletedTask;
+        }
+
+        public object ParsePaymentPromptDetails(JToken details)
+        {
+            return details.ToObject<DePixPaymentMethodDetails>(Serializer)!;
+        }
+
+        public object ParsePaymentMethodConfig(JToken config)
+        {
+            return new object();
+        }
+
+        public object ParsePaymentDetails(JToken details)
+        {
+            return details.ToObject<DePixPaymentData>(Serializer)!;
+        }
+    }
+}

--- a/BTCPayServer.Plugins.Depix/Data/Enums/DePixPaymentStatus.cs
+++ b/BTCPayServer.Plugins.Depix/Data/Enums/DePixPaymentStatus.cs
@@ -7,6 +7,7 @@ public enum DepixStatus
 {
     Pending,
     UnderReview,
+    Approved,
     DepixSent,
     Error,
     Refunded,
@@ -24,15 +25,67 @@ public static class DepixStatusExtensions
         var s = value.Trim().ToLowerInvariant().Replace("-", "_");
         switch (s)
         {
-            case "pending":       result = DepixStatus.Pending;     return true;
-            case "under_review":  result = DepixStatus.UnderReview; return true;
-            case "depix_sent":    result = DepixStatus.DepixSent;   return true;
-            case "error":         result = DepixStatus.Error;       return true;
-            case "refunded":      result = DepixStatus.Refunded;    return true;
-            case "expired":       result = DepixStatus.Expired;     return true;
-            case "canceled":      result = DepixStatus.Canceled;    return true;
+            case "pending":        result = DepixStatus.Pending;       return true;
+            case "under_review":   result = DepixStatus.UnderReview;   return true;
+            case "approved":       result = DepixStatus.Approved;      return true;
+            case "depix_sent":     result = DepixStatus.DepixSent;     return true;
+            case "error":          result = DepixStatus.Error;         return true;
+            case "refunded":       result = DepixStatus.Refunded;      return true;
+            case "expired":        result = DepixStatus.Expired;       return true;
+            case "canceled":       result = DepixStatus.Canceled;      return true;
             default: return false;
         }
+    }
+
+    public static bool IsConfirmedPaymentStatus(this DepixStatus s)
+    {
+        return s is DepixStatus.Approved or DepixStatus.DepixSent;
+    }
+
+    public static bool IsTerminalStatus(this DepixStatus s)
+    {
+        return s is DepixStatus.Canceled or DepixStatus.Error or DepixStatus.Expired or DepixStatus.Refunded;
+    }
+
+    public static string ToApiString(this DepixStatus s)
+    {
+        return s switch
+        {
+            DepixStatus.Pending => "pending",
+            DepixStatus.UnderReview => "under_review",
+            DepixStatus.Approved => "approved",
+            DepixStatus.DepixSent => "depix_sent",
+            DepixStatus.Error => "error",
+            DepixStatus.Refunded => "refunded",
+            DepixStatus.Expired => "expired",
+            DepixStatus.Canceled => "canceled",
+            _ => s.ToString()
+        };
+    }
+
+    public static bool ShouldReplace(this DepixStatus incoming, string? currentStatus)
+    {
+        if (!TryParse(currentStatus, out var current))
+            return true;
+        if (incoming == current)
+            return true;
+        if (current.IsTerminalStatus())
+            return false;
+        if (incoming.IsTerminalStatus())
+            return true;
+
+        return incoming.ProgressionRank() >= current.ProgressionRank();
+    }
+
+    private static int ProgressionRank(this DepixStatus s)
+    {
+        return s switch
+        {
+            DepixStatus.DepixSent => 3,
+            DepixStatus.Approved => 2,
+            DepixStatus.Pending => 0,
+            _ => 1
+        };
     }
 
     public static InvoiceState? ToInvoiceState(this DepixStatus s, InvoiceState current)
@@ -43,7 +96,7 @@ public static class DepixStatusExtensions
             DepixStatus.UnderReview => current.Status == InvoiceStatus.Settled
                 ? null
                 : new InvoiceState(InvoiceStatus.Processing, InvoiceExceptionStatus.None),
-            DepixStatus.DepixSent => new InvoiceState(InvoiceStatus.Settled, InvoiceExceptionStatus.None),
+            DepixStatus.Approved or DepixStatus.DepixSent => new InvoiceState(InvoiceStatus.Settled, InvoiceExceptionStatus.None),
             DepixStatus.Expired => current.Status == InvoiceStatus.Settled
                 ? null
                 : new InvoiceState(InvoiceStatus.Expired, InvoiceExceptionStatus.None),

--- a/BTCPayServer.Plugins.Depix/Data/Models/DepositWebhookBody.cs
+++ b/BTCPayServer.Plugins.Depix/Data/Models/DepositWebhookBody.cs
@@ -14,6 +14,6 @@ public sealed class DepositWebhookBody
     [JsonPropertyName("expiration")] public string? Expiration { get; set; } // ISO string
     [JsonPropertyName("pixKey")] public string? PixKey { get; set; }
     [JsonPropertyName("qrId")] public string QrId { get; set; } = null!;
-    [JsonPropertyName("status")] public string? Status { get; set; } // ex: depix_sent
+    [JsonPropertyName("status")] public string? Status { get; set; } // ex: approved, depix_sent
     [JsonPropertyName("valueInCents")] public int? ValueInCents { get; set; }
 }

--- a/BTCPayServer.Plugins.Depix/PaymentHandlers/PixPaymentMethodHandler.cs
+++ b/BTCPayServer.Plugins.Depix/PaymentHandlers/PixPaymentMethodHandler.cs
@@ -69,9 +69,7 @@ public class PixPaymentMethodHandler(
         if (string.IsNullOrWhiteSpace(apiKey))
             throw new PaymentMethodUnavailableException("DePix API key not configured");
 
-        var amountInBrl = context.Prompt.Calculate().Due;
-        if (effectiveConfig.PassFeeToCustomer) amountInBrl += 1.00m;
-        var amountInCents = (int)Math.Round(amountInBrl * 100m, MidpointRounding.AwayFromZero);
+        var amountInCents = (int)Math.Round(context.Prompt.Calculate().Due * 100m, MidpointRounding.AwayFromZero);
 
         using var client = depixService.CreateDepixClient(apiKey);
 
@@ -84,9 +82,9 @@ public class PixPaymentMethodHandler(
             effectiveConfig.UseWhitelist,
             CancellationToken.None);
 
-        depixService.ApplyPromptDetails(context, deposit, address);
+        depixService.ApplyPromptDetails(context, deposit, address, amountInCents);
     }
-    
+
     /// <summary>
     /// JSON serializer for the handler
     /// </summary>
@@ -205,7 +203,6 @@ public class DePixPaymentMethodDetails
     /// Expiration time
     /// </summary>
     public string? Expiration { get; set; }
-    /// <summary>
     /// The Pix key
     /// </summary>
     public string? PixKey { get; set; }

--- a/BTCPayServer.Plugins.Depix/Services/DepixService.cs
+++ b/BTCPayServer.Plugins.Depix/Services/DepixService.cs
@@ -361,8 +361,11 @@ public class DepixService(
             "\"StoreDataId\" = @storeId",
             "(\"Blob2\"->'prompts'->'PIX'->'details'->>'qrId') IS NOT NULL"
         };
-        if (!string.IsNullOrWhiteSpace(query.Status))
-            where.Add("\"Blob2\"->'prompts'->'PIX'->'details'->>'status' = @status");
+        var status = NormalizeStatusFilter(query.Status);
+        if (!string.IsNullOrWhiteSpace(status))
+        {
+            where.Add("LOWER(REPLACE(COALESCE(\"Blob2\"->'prompts'->'PIX'->'details'->>'status', ''), '-', '_')) = @status");
+        }
         if (query.From is not null)
             where.Add("\"Created\" >= @fromUtc");
         if (query.To is not null)
@@ -395,7 +398,7 @@ public class DepixService(
         var args = new
         {
             storeId = query.StoreId,
-            status  = query.Status,
+            status,
             search  = query.SearchTerm,
             fromUtc = query.From?.UtcDateTime,
             toUtc   = query.To?.UtcDateTime
@@ -488,70 +491,139 @@ public class DepixService(
             return;
         }
 
-        var details = pixPrompt.Details is null
-            ? new DePixPaymentMethodDetails()
-            : handler.ParsePaymentPromptDetails(pixPrompt.Details) as DePixPaymentMethodDetails ??
-              new DePixPaymentMethodDetails();
-        if (body.Status is not null)       details.Status = body.Status;
-        if (body.ValueInCents is not null) details.ValueInCents = body.ValueInCents;
+        var hasDepixStatus = DepixStatusExtensions.TryParse(body.Status, out var depixStatus);
+        var expectedValueInCents = TryGetExpectedValueInCents(entity, pixPrompt, body.QrId, handler);
+        var effectivePromptStatus = TryGetPromptStatus(pixPrompt, handler);
+        try
+        {
+            effectivePromptStatus = await UpdatePromptDetailsFromWebhookAsync(
+                invoiceId,
+                body,
+                handler,
+                expectedValueInCents,
+                cancellationToken) ?? effectivePromptStatus;
+        }
+        catch (Exception ex) when (hasDepixStatus &&
+                                   ex is not OperationCanceledException)
+        {
+            logger.LogWarning(ex, "Depix webhook: could not update PIX prompt details before applying status {Status} for invoice {InvoiceId}", body.Status, invoiceId);
+        }
+
+        if (!hasDepixStatus)
+        {
+            await TryUpdateExistingPaymentAndPublishAsync(entity, pixPrompt, body, expectedValueInCents, handler, cancellationToken);
+            return;
+        }
+
+        if (!depixStatus.IsConfirmedPaymentStatus())
+        {
+            await TryUpdateExistingPaymentAndPublishAsync(entity, pixPrompt, body, expectedValueInCents, handler, cancellationToken);
+            await ApplyStatusAndNotifyAsync(invoiceId, depixStatus);
+            return;
+        }
+
+        if (!depixStatus.ShouldReplace(effectivePromptStatus))
+        {
+            await TryUpdateExistingPaymentAndPublishAsync(entity, pixPrompt, body, expectedValueInCents, handler, cancellationToken);
+            return;
+        }
+
+        await TryRecordPaymentAsync(entity, pixPrompt, body, depixStatus, expectedValueInCents, handler, cancellationToken);
+    }
+
+    private async Task<string?> UpdatePromptDetailsFromWebhookAsync(
+        string invoiceId,
+        DepositWebhookBody body,
+        IPaymentMethodHandler handler,
+        int? expectedValueInCents,
+        CancellationToken cancellationToken)
+    {
+        const int maxAttempts = 5;
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await using var db = dbFactory.CreateContext();
+            try
+            {
+                var invoiceData = await db.Invoices.FindAsync([invoiceId], cancellationToken);
+                if (invoiceData is null)
+                    return null;
+
+                var invoiceEntity = invoiceData.GetBlob();
+                var prompt = invoiceEntity.GetPaymentPrompt(handler.PaymentMethodId);
+                if (prompt is null)
+                    return null;
+
+                var details = prompt.Details is null
+                    ? new DePixPaymentMethodDetails()
+                    : handler.ParsePaymentPromptDetails(prompt.Details) as DePixPaymentMethodDetails ??
+                      new DePixPaymentMethodDetails();
+
+                ApplyWebhookBodyToDetails(details, body, expectedValueInCents);
+
+                prompt.Details = JToken.FromObject(details, handler.Serializer);
+                invoiceEntity.SetPaymentPrompt(handler.PaymentMethodId, prompt);
+                invoiceData.SetBlob(invoiceEntity);
+                await db.SaveChangesAsync(cancellationToken);
+                return details.Status;
+            }
+            catch (DbUpdateConcurrencyException) when (attempt + 1 < maxAttempts)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+        }
+
+        return null;
+    }
+
+    private static void ApplyWebhookBodyToDetails(
+        DePixPaymentMethodDetails details,
+        DepositWebhookBody body,
+        int? expectedValueInCents)
+    {
+        if (body.Status is not null)       details.Status = MergeStatus(body.Status, details.Status);
+        if (TryGetWebhookValueInCents(body, expectedValueInCents) is { } valueInCents && details.ValueInCents is null)
+            details.ValueInCents = valueInCents;
         if (body.Expiration is not null)   details.Expiration = body.Expiration;
         if (body.PixKey is not null)       details.PixKey = body.PixKey;
 
-        if (body.PayerName is not null || body.PayerEuid is not null ||
-            body.PayerTaxNumber is not null || body.CustomerMessage is not null)
+        if (body.PayerName is null && body.PayerEuid is null &&
+            body.PayerTaxNumber is null && body.CustomerMessage is null)
         {
-            details.Payer ??= new DePixPaymentMethodDetails.PayerDetails();
-            if (body.PayerName is not null)       details.Payer.Name = body.PayerName;
-            if (body.PayerEuid is not null)       details.Payer.Euid = body.PayerEuid;
-            if (body.PayerTaxNumber is not null)  details.Payer.TaxNumber = body.PayerTaxNumber;
-            if (body.CustomerMessage is not null) details.Payer.Message = body.CustomerMessage;
+            return;
         }
 
-        await invoiceRepository.UpdatePaymentDetails(invoiceId, handler, details);
-
-        if (DepixStatusExtensions.TryParse(body.Status, out var depixStatus))
-        {
-            if (depixStatus != DepixStatus.DepixSent)
-            {
-                await ApplyStatusAndNotifyAsync(invoiceId, depixStatus);
-                return;
-            }
-            
-            await TryRecordPaymentAsync(entity, pixPrompt, body, depixStatus);
-        }
+        details.Payer ??= new DePixPaymentMethodDetails.PayerDetails();
+        if (body.PayerName is not null)       details.Payer.Name = body.PayerName;
+        if (body.PayerEuid is not null)       details.Payer.Euid = body.PayerEuid;
+        if (body.PayerTaxNumber is not null)  details.Payer.TaxNumber = body.PayerTaxNumber;
+        if (body.CustomerMessage is not null) details.Payer.Message = body.CustomerMessage;
     }
 
     private async Task TryRecordPaymentAsync(InvoiceEntity entity, PaymentPrompt pixPrompt, DepositWebhookBody body,
-        DepixStatus depixStatus)
+        DepixStatus depixStatus, int? expectedValueInCents, IPaymentMethodHandler handler, CancellationToken cancellationToken)
     {
-        if (depixStatus != DepixStatus.DepixSent)
+        if (!depixStatus.IsConfirmedPaymentStatus())
             return;
 
         if (string.IsNullOrWhiteSpace(body.QrId))
         {
-            logger.LogWarning("Depix webhook: depix_sent without payment id for invoice {InvoiceId}", entity.Id);
+            logger.LogWarning("Depix webhook: confirmed status {Status} without payment id for invoice {InvoiceId}", body.Status, entity.Id);
             return;
         }
 
-        var amount = body.ValueInCents is { } cents
-            ? cents / 100m
-            : pixPrompt.Calculate().TotalDue;
+        var expectedAmount = expectedValueInCents is > 0 ? expectedValueInCents.Value / 100m : pixPrompt.Calculate().Due;
+        var amount = TryGetWebhookAmount(body, expectedValueInCents) ?? expectedAmount;
         if (amount <= 0m)
         {
-            logger.LogWarning("Depix webhook: depix_sent with invalid amount {Amount} for invoice {InvoiceId}", amount, entity.Id);
+            logger.LogWarning("Depix webhook: confirmed status {Status} with invalid amount {Amount} for invoice {InvoiceId}", body.Status, amount, entity.Id);
             return;
         }
 
         using var scope = scopeFactory.CreateScope();
         var paymentService = scope.ServiceProvider.GetRequiredService<PaymentService>();
-        var handlers = scope.ServiceProvider.GetRequiredService<PaymentMethodHandlerDictionary>();
-        if (!handlers.TryGetValue(DePixPlugin.PixPmid, out var handler))
-        {
-            logger.LogWarning("Depix webhook: depix_sent but PIX handler missing for invoice {InvoiceId}", entity.Id);
-            return;
-        }
 
-        var paymentId = $"{entity.Id}:{body.QrId}";
+        var paymentId = GetPaymentId(entity.Id, body.QrId);
         var paymentData = new PaymentData
         {
             Id = paymentId,
@@ -560,11 +632,17 @@ public class DepixService(
             Currency = pixPrompt.Currency,
             InvoiceDataId = entity.Id,
             Amount = amount
-        }.Set(entity, handler, BuildPaymentData(body));
+        }.Set(entity, handler, BuildPaymentData(body, valueInCents: TryGetWebhookValueInCents(body, expectedValueInCents)));
 
         var payment = await paymentService.AddPayment(paymentData, new HashSet<string>(StringComparer.OrdinalIgnoreCase) { paymentId });
         if (payment is null)
         {
+            if (await TryUpdateExistingPaymentAsync(paymentId, entity, pixPrompt, body, amount, handler, cancellationToken))
+            {
+                await PublishExistingPaymentUpdatedAsync(entity.Id);
+                return;
+            }
+
             events.Publish(new InvoiceNeedUpdateEvent(entity.Id));
             return;
         }
@@ -574,21 +652,229 @@ public class DepixService(
             events.Publish(new InvoiceEvent(invoice, InvoiceEvent.ReceivedPayment) { Payment = payment });
     }
 
-    private static DePixPaymentData BuildPaymentData(DepositWebhookBody body)
+    private async Task PublishExistingPaymentUpdatedAsync(string invoiceId)
+    {
+        events.Publish(new InvoiceNeedUpdateEvent(invoiceId));
+
+        var invoice = await invoiceRepository.GetInvoice(invoiceId);
+        if (invoice is not null)
+            events.Publish(new InvoiceDataChangedEvent(invoice));
+    }
+
+    private async Task TryUpdateExistingPaymentAndPublishAsync(
+        InvoiceEntity entity,
+        PaymentPrompt pixPrompt,
+        DepositWebhookBody body,
+        int? expectedValueInCents,
+        IPaymentMethodHandler handler,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(body.QrId))
+            return;
+
+        if (await TryUpdateExistingPaymentAsync(
+                GetPaymentId(entity.Id, body.QrId),
+                entity,
+                pixPrompt,
+                body,
+                TryGetWebhookAmount(body, expectedValueInCents),
+                handler,
+                cancellationToken))
+        {
+            await PublishExistingPaymentUpdatedAsync(entity.Id);
+        }
+    }
+
+    private async Task<bool> TryUpdateExistingPaymentAsync(
+        string paymentId,
+        InvoiceEntity entity,
+        PaymentPrompt pixPrompt,
+        DepositWebhookBody body,
+        decimal? amount,
+        IPaymentMethodHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var paymentMethodId = handler.PaymentMethodId.ToString();
+        await using var strategyContext = dbFactory.CreateContext();
+        return await strategyContext.Database.CreateExecutionStrategy().ExecuteAsync(async () =>
+        {
+            await using var db = dbFactory.CreateContext();
+            await using var transaction = await db.Database.BeginTransactionAsync(cancellationToken);
+            var existing = await db.Payments
+                .FromSqlInterpolated($"""
+                                      SELECT *
+                                      FROM "Payments"
+                                      WHERE "Id" = {paymentId} AND "PaymentMethodId" = {paymentMethodId}
+                                      FOR UPDATE
+                                      """)
+                .SingleOrDefaultAsync(cancellationToken);
+            if (existing is null)
+                return false;
+
+            if (!TryParsePaymentDetails(existing, handler, out var existingDetails))
+                return false;
+
+            var acceptedAmount = existing.Amount is > 0m ? existing.Amount : amount;
+            if (amount is > 0m && existing.Amount is not > 0m)
+            {
+                existing.Amount = amount;
+            }
+            else if (amount is > 0m && existing.Amount != amount)
+            {
+                logger.LogWarning(
+                    "Depix webhook: ignoring mismatched amount {IncomingAmount} for existing payment {PaymentId} with amount {ExistingAmount}",
+                    amount,
+                    paymentId,
+                    existing.Amount);
+            }
+
+            var acceptedValueInCents = acceptedAmount is > 0m ? (int?)ToValueInCents(acceptedAmount.Value) : null;
+            existing.Currency = pixPrompt.Currency;
+            existing.Status = PaymentStatus.Settled;
+            existing.Set(entity, handler, BuildPaymentData(
+                body,
+                existingDetails,
+                TryGetWebhookValueInCents(body, acceptedValueInCents)));
+
+            await db.SaveChangesAsync(cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+            return true;
+        });
+    }
+
+    private bool TryParsePaymentDetails(
+        PaymentData paymentData,
+        IPaymentMethodHandler handler,
+        out DePixPaymentData? details)
+    {
+        try
+        {
+            details = paymentData.GetBlob().GetDetails<DePixPaymentData>(handler);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Depix webhook: could not parse existing payment details for payment {PaymentId}", paymentData.Id);
+            details = null;
+            return false;
+        }
+    }
+
+    private static DePixPaymentData BuildPaymentData(
+        DepositWebhookBody body,
+        DePixPaymentData? existing = null,
+        int? valueInCents = null)
     {
         return new DePixPaymentData
         {
-            QrId = body.QrId,
-            BankTxId = body.BankTxId,
-            BlockchainTxId = body.BlockchainTxId,
-            Status = body.Status,
-            ValueInCents = body.ValueInCents,
-            PixKey = body.PixKey,
-            PayerName = body.PayerName,
-            PayerEuid = body.PayerEuid,
-            PayerTaxNumber = body.PayerTaxNumber,
-            CustomerMessage = body.CustomerMessage
+            QrId = body.QrId ?? existing?.QrId,
+            BankTxId = body.BankTxId ?? existing?.BankTxId,
+            BlockchainTxId = body.BlockchainTxId ?? existing?.BlockchainTxId,
+            Status = MergeStatus(body.Status, existing?.Status),
+            ValueInCents = existing?.ValueInCents ?? valueInCents,
+            PixKey = body.PixKey ?? existing?.PixKey,
+            PayerName = body.PayerName ?? existing?.PayerName,
+            PayerEuid = body.PayerEuid ?? existing?.PayerEuid,
+            PayerTaxNumber = body.PayerTaxNumber ?? existing?.PayerTaxNumber,
+            CustomerMessage = body.CustomerMessage ?? existing?.CustomerMessage
         };
+    }
+
+    private static string GetPaymentId(string invoiceId, string qrId)
+    {
+        return $"{invoiceId}:{qrId}";
+    }
+
+    private static int? TryGetExpectedValueInCents(
+        InvoiceEntity entity,
+        PaymentPrompt prompt,
+        string? qrId,
+        IPaymentMethodHandler handler)
+    {
+        if (TryGetStoredPromptValueInCents(prompt, handler) is { } storedValueInCents)
+            return storedValueInCents;
+
+        var promptAmount = prompt.Calculate().Due;
+        if (promptAmount > 0m)
+            return ToValueInCents(promptAmount);
+
+        if (string.IsNullOrWhiteSpace(qrId))
+            return null;
+
+        var existingPayment = entity
+            .GetPayments(false)
+            .FirstOrDefault(payment =>
+                payment.PaymentMethodId == handler.PaymentMethodId &&
+                string.Equals(payment.Id, GetPaymentId(entity.Id, qrId), StringComparison.Ordinal));
+
+        return existingPayment?.Value is > 0m ? ToValueInCents(existingPayment.Value) : null;
+    }
+
+    private static int? TryGetStoredPromptValueInCents(PaymentPrompt prompt, IPaymentMethodHandler? handler)
+    {
+        if (prompt.Details is null || handler is null)
+            return null;
+
+        return handler.ParsePaymentPromptDetails(prompt.Details) is DePixPaymentMethodDetails { ValueInCents: > 0 } details
+            ? details.ValueInCents
+            : null;
+    }
+
+    private static string? TryGetPromptStatus(PaymentPrompt prompt, IPaymentMethodHandler handler)
+    {
+        if (prompt.Details is null)
+            return null;
+
+        return handler.ParsePaymentPromptDetails(prompt.Details) is DePixPaymentMethodDetails details
+            ? details.Status
+            : null;
+    }
+
+    private static int? TryGetWebhookValueInCents(DepositWebhookBody body)
+    {
+        return body.ValueInCents is > 0 ? body.ValueInCents.Value : null;
+    }
+
+    private static int? TryGetWebhookValueInCents(DepositWebhookBody body, int? expectedValueInCents)
+    {
+        var valueInCents = TryGetWebhookValueInCents(body);
+        if (valueInCents is null || expectedValueInCents is null)
+            return null;
+        if (valueInCents == expectedValueInCents)
+            return valueInCents;
+
+        return null;
+    }
+
+    private static decimal? TryGetWebhookAmount(DepositWebhookBody body, int? expectedValueInCents)
+    {
+        return TryGetWebhookValueInCents(body, expectedValueInCents) is { } valueInCents ? valueInCents / 100m : null;
+    }
+
+    private static int ToValueInCents(decimal amount)
+    {
+        return (int)Math.Round(amount * 100m, MidpointRounding.AwayFromZero);
+    }
+
+    private static string? MergeStatus(string? incomingStatus, string? existingStatus)
+    {
+        if (string.IsNullOrWhiteSpace(incomingStatus))
+            return existingStatus;
+
+        if (DepixStatusExtensions.TryParse(incomingStatus, out var incoming))
+            return incoming.ShouldReplace(existingStatus) ? incoming.ToApiString() : existingStatus;
+
+        return DepixStatusExtensions.TryParse(existingStatus, out _) ? existingStatus : incomingStatus.Trim();
+    }
+
+    private static string? NormalizeStatusFilter(string? status)
+    {
+        if (string.IsNullOrWhiteSpace(status))
+            return null;
+
+        return DepixStatusExtensions.TryParse(status, out var parsed)
+            ? parsed.ToApiString()
+            : status.Trim().ToLowerInvariant().Replace("-", "_");
     }
 
     private async Task ApplyStatusAndNotifyAsync(string invoiceId, DepixStatus depix)

--- a/BTCPayServer.Plugins.Depix/Services/DepixService.cs
+++ b/BTCPayServer.Plugins.Depix/Services/DepixService.cs
@@ -323,7 +323,8 @@ public class DepixService(
     /// <param name="context">The payment method context</param>
     /// <param name="depositResponse">The deposit response from DePix</param>
     /// <param name="depixAddress">The DePix address</param>
-    public void ApplyPromptDetails(PaymentMethodContext context, DepixDepositResponse depositResponse, string depixAddress)
+    /// <param name="amountInCents">The QR amount in cents</param>
+    public void ApplyPromptDetails(PaymentMethodContext context, DepixDepositResponse depositResponse, string depixAddress, int amountInCents)
     {
         context.Prompt.Destination = depositResponse.QrImageUrl;
 
@@ -336,6 +337,8 @@ public class DepixService(
         details.QrImageUrl = depositResponse.QrImageUrl;
         details.CopyPaste = depositResponse.QrCopyPaste;
         details.DepixAddress = depixAddress;
+        if (amountInCents > 0)
+            details.ValueInCents = amountInCents;
 
         context.Prompt.Details = JToken.FromObject(details, context.Handler.Serializer);
     }

--- a/BTCPayServer.Plugins.Depix/Views/Pix/PixTransactions.cshtml
+++ b/BTCPayServer.Plugins.Depix/Views/Pix/PixTransactions.cshtml
@@ -1,5 +1,6 @@
 @using BTCPayServer.Abstractions.Extensions
 @using BTCPayServer.Plugins.Depix
+@using BTCPayServer.Plugins.Depix.Data.Enums
 @model BTCPayServer.Plugins.Depix.Data.Models.ViewModels.PixTransactionsViewModel
 
 @{
@@ -19,6 +20,7 @@
 
   string Badge(string s) => (s ?? "").ToLowerInvariant() switch
   {
+      "approved" => "bg-success",
       "depix_sent" => "bg-success",
       "under_review" => "bg-warning text-dark",
       "pending" => "bg-secondary",
@@ -105,7 +107,7 @@ else if (!Model.ConfigStatus.PixEnabled)
             <label class="form-label" text-translate="true">Status</label>
             <select name="status" class="form-select">
                 <option value="" text-translate="true">All</option>
-                @foreach (var s in new[] { "depix_sent","under_review","pending","expired","canceled","error","refunded" })
+                @foreach (var s in new[] { "approved","depix_sent","under_review","pending","expired","canceled","error","refunded" })
                 {
                     <option value="@s" selected="@(statusFilter==s)">@s</option>
                 }
@@ -152,7 +154,9 @@ else if (!Model.ConfigStatus.PixEnabled)
         <tbody>
         @foreach (var d in Model.Transactions)
         {
-            var raw = d.DepixStatus?.ToString() ?? d.DepixStatusRaw;
+            var raw = d.DepixStatus is { } parsed
+                ? parsed.ToApiString()
+                : d.DepixStatusRaw;
             <tr>
                 <td class="text-nowrap">
                     <time datetime="@d.Created.UtcDateTime.ToString("o")">


### PR DESCRIPTION
Treats DePix approved webhooks as payment confirmation so Pix deposits can settle before the slower depix_sent event arrives.

Resolves #34 

Changes:

- Adds approved as a confirmed DePix deposit status.
- Settles the Pix payment on approved.
- Keeps depix_sent idempotent by updating the existing payment with final blockchain/details instead of creating a duplicate.
- Preserves QR expected amount and ignores mismatched webhook amounts.
- Fixes DePix fee handling so the QR amount uses the prompt due amount without adding the fee twice.
- Adds focused tests for status handling, QR amount persistence, webhook ordering, duplicate updates, and amount mismatch behavior.