### PR TITLE
[Feature] Add DePix P2P mode with dedicated seller commission

### DIFF
--- a/BTCPayServer.Plugins.Depix.Tests/DepixWebhookServiceTests.cs
+++ b/BTCPayServer.Plugins.Depix.Tests/DepixWebhookServiceTests.cs
@@ -185,6 +185,58 @@ public sealed class DepixWebhookServiceTests : IAsyncLifetime
     }
 
     [Fact(Timeout = TestUtils.TestTimeout)]
+    public async Task CreatedP2PInvoiceIsRestrictedToPixPaymentPrompt()
+    {
+        var storeId = await CreateStoreAsync();
+        var handlers = _server.PayTester.GetService<PaymentMethodHandlerDictionary>();
+        var pixHandler = handlers[PixPmid];
+        var invoiceRepository = _server.PayTester.InvoiceRepository;
+        var storeRepository = _server.PayTester.GetService<StoreRepository>();
+        var store = await storeRepository.FindStore(storeId) ?? throw new InvalidOperationException("Store not found.");
+        var invoice = invoiceRepository.CreateNewInvoice(storeId);
+        invoice.Currency = "BRL";
+        invoice.Price = 12.34m;
+        invoice.AddRate(new CurrencyPair("BRL", "BRL"), 1m);
+        invoice.SetPaymentPrompts(new PaymentPromptDictionary([
+            new PaymentPrompt
+            {
+                PaymentMethodId = PixPmid,
+                Currency = "BRL",
+                Divisibility = 2,
+                Destination = "https://example.invalid/pix.png",
+                Details = JToken.FromObject(new DePixPaymentMethodDetails
+                {
+                    QrId = "qr-p2p-restricted",
+                    P2PMode = true,
+                    ValueInCents = 1234
+                }, pixHandler.Serializer)
+            },
+            new PaymentPrompt
+            {
+                PaymentMethodId = PaymentTypes.CHAIN.GetPaymentMethodId("BTC"),
+                Currency = "BRL",
+                Divisibility = 2,
+                Destination = "bitcoin-address",
+                Details = new JObject()
+            }
+        ]));
+
+        await invoiceRepository.CreateInvoiceAsync(new InvoiceCreationContext(
+            store,
+            store.GetStoreBlob(),
+            invoice,
+            new InvoiceLogs(),
+            handlers,
+            invoicePaymentMethodFilter: null));
+
+        _server.PayTester.GetService<EventAggregator>().Publish(new InvoiceEvent(invoice, InvoiceEvent.Created));
+
+        var storedInvoice = await invoiceRepository.GetInvoice(invoice.Id);
+        var prompt = Assert.Single(storedInvoice.GetPaymentPrompts());
+        Assert.Equal(PixPmid, prompt.PaymentMethodId);
+    }
+
+    [Fact(Timeout = TestUtils.TestTimeout)]
     public async Task FirstConfirmedWebhookWithMismatchedAmountUsesPromptAmount()
     {
         var storeId = await CreateStoreAsync();

--- a/BTCPayServer.Plugins.Depix.Tests/DepixWebhookServiceTests.cs
+++ b/BTCPayServer.Plugins.Depix.Tests/DepixWebhookServiceTests.cs
@@ -263,6 +263,61 @@ public sealed class DepixWebhookServiceTests : IAsyncLifetime
         Assert.Equal(1234, promptDetails.ValueInCents);
     }
 
+    [Fact(Timeout = TestUtils.TestTimeout)]
+    public async Task ConfigurePromptReturnsUnavailableWhenP2PCommissionAddressCannotBeGenerated()
+    {
+        var storeId = await CreateStoreAsync();
+        var storeRepository = _server.PayTester.GetService<StoreRepository>();
+        var handlers = _server.PayTester.GetService<PaymentMethodHandlerDictionary>();
+        var handler = handlers[PixPmid];
+        var protector = _server.PayTester.GetService<ISecretProtector>();
+        var store = await storeRepository.FindStore(storeId) ?? throw new InvalidOperationException("Store not found.");
+
+        store.SetPaymentMethodConfig(handler, new PixPaymentMethodConfig
+        {
+            EncryptedApiKey = protector.Protect("fixture-api-key"),
+            WebhookSecretHashHex = BTCPayServer.Plugins.Depix.Services.Utils.ComputeSecretHash(
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+            IsEnabled = true,
+            P2PMode = true,
+            P2PCommissionPercent = "5%"
+        });
+        var storeBlob = store.GetStoreBlob();
+        storeBlob.SetExcluded(PixPmid, false);
+        store.SetStoreBlob(storeBlob);
+        await storeRepository.UpdateStore(store);
+
+        var invoice = _server.PayTester.InvoiceRepository.CreateNewInvoice(storeId);
+        invoice.Currency = "BRL";
+        invoice.Price = 12.34m;
+        invoice.AddRate(new CurrencyPair("BRL", "BRL"), 1m);
+#pragma warning disable CS0618
+        invoice.Payments = [];
+#pragma warning restore CS0618
+        invoice.UpdateTotals();
+        invoice.Metadata = new InvoiceMetadata
+        {
+            AdditionalData = new Dictionary<string, JToken>
+            {
+                ["depixAddress"] = "buyer-depix-address"
+            }
+        };
+        var context = new PaymentMethodContext(
+            store,
+            store.GetStoreBlob(),
+            new JObject(),
+            handler,
+            invoice,
+            new InvoiceLogs());
+        context.Prompt.ParentEntity = invoice;
+        context.Prompt.PaymentMethodId = PixPmid;
+        context.Prompt.Currency = "BRL";
+        context.Prompt.Divisibility = 2;
+
+        var ex = await Assert.ThrowsAsync<PaymentMethodUnavailableException>(() => handler.ConfigurePrompt(context));
+        Assert.Contains("DePix", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     private async Task<string> CreateStoreAsync()
     {
         var account = _server.NewAccount();

--- a/BTCPayServer.Plugins.Depix.Tests/DepixWebhookServiceTests.cs
+++ b/BTCPayServer.Plugins.Depix.Tests/DepixWebhookServiceTests.cs
@@ -231,9 +231,12 @@ public sealed class DepixWebhookServiceTests : IAsyncLifetime
 
         _server.PayTester.GetService<EventAggregator>().Publish(new InvoiceEvent(invoice, InvoiceEvent.Created));
 
-        var storedInvoice = await invoiceRepository.GetInvoice(invoice.Id);
-        var prompt = Assert.Single(storedInvoice.GetPaymentPrompts());
-        Assert.Equal(PixPmid, prompt.PaymentMethodId);
+        await TestUtils.EventuallyAsync(async () =>
+        {
+            var storedInvoice = await invoiceRepository.GetInvoice(invoice.Id);
+            var prompt = Assert.Single(storedInvoice.GetPaymentPrompts());
+            Assert.Equal(PixPmid, prompt.PaymentMethodId);
+        });
     }
 
     [Fact(Timeout = TestUtils.TestTimeout)]

--- a/BTCPayServer.Plugins.Depix.Tests/PixPaymentMethodHandlerTests.cs
+++ b/BTCPayServer.Plugins.Depix.Tests/PixPaymentMethodHandlerTests.cs
@@ -1,11 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Data;
 using BTCPayServer.Logging;
 using BTCPayServer.Payments;
 using BTCPayServer.Plugins.Depix.Data.Models;
+using BTCPayServer.Plugins.Depix.Errors;
 using BTCPayServer.Plugins.Depix.PaymentHandlers;
 using BTCPayServer.Plugins.Depix.Services;
+using BTCPayServer.Rating;
 using BTCPayServer.Services.Invoices;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -16,6 +25,28 @@ namespace BTCPayServer.Plugins.Depix.Tests;
 public class PixPaymentMethodHandlerTests
 {
     private static readonly PaymentMethodId PixPmid = new("PIX");
+
+    [Theory]
+    [InlineData("0,5", "0.5%")]
+    [InlineData("0.5", "0.5%")]
+    [InlineData("5%", "5%")]
+    [InlineData("5,25%", "5.25%")]
+    public void TryNormalizeSplitFeeAcceptsDecimalCommaWithoutThousands(string raw, string expected)
+    {
+        Assert.True(DepixService.TryNormalizeSplitFee(raw, out var normalized));
+        Assert.Equal(expected, normalized);
+    }
+
+    [Theory]
+    [InlineData("1,000")]
+    [InlineData("1.000")]
+    [InlineData("1,000.00")]
+    [InlineData("1.000,00")]
+    [InlineData("5 percent")]
+    public void TryNormalizeSplitFeeRejectsThousandsAndFreeText(string raw)
+    {
+        Assert.False(DepixService.TryNormalizeSplitFee(raw, out _));
+    }
 
     [Fact]
     public void ApplyPromptDetailsPersistsQrAmountValueInCents()
@@ -48,6 +79,303 @@ public class PixPaymentMethodHandlerTests
         Assert.Equal(1234, details.ValueInCents);
     }
 
+    [Fact]
+    public void ApplyPromptDetailsPersistsP2PCommissionDetails()
+    {
+        var handler = new TestPixHandler();
+        var invoice = new InvoiceEntity
+        {
+            Id = "invoice-prompt-p2p-details",
+            Currency = "BRL",
+            Price = 12.34m,
+            Status = InvoiceStatus.New
+        };
+        var context = new PaymentMethodContext(
+            new BTCPayServer.Data.StoreData { Id = "store-prompt-p2p-details" },
+            new StoreBlob(),
+            new JObject(),
+            handler,
+            invoice,
+            new InvoiceLogs());
+        var service = new DepixService(null!, null!, null!, null!, null!, null!, null!, null!, null!);
+
+        service.ApplyPromptDetails(
+            context,
+            new DepixDepositResponse("qr-p2p-details", "https://example.invalid/qr.png", "copy-paste"),
+            "buyer-depix-address",
+            1234,
+            p2PMode: true,
+            depixSplitAddress: "fresh-store-commission-address",
+            p2PCommissionPercent: "5%");
+
+        var details = Assert.IsType<DePixPaymentMethodDetails>(handler.ParsePaymentPromptDetails(context.Prompt.Details));
+        Assert.True(details.P2PMode);
+        Assert.Equal("buyer-depix-address", details.DepixAddress);
+        Assert.Equal("fresh-store-commission-address", details.DepixSplitAddress);
+        Assert.Equal("5%", details.P2PCommissionPercent);
+        Assert.Null(details.SplitFee);
+    }
+
+    [Fact]
+    public void ApplyPromptDetailsClearsP2PCommissionDetailsForNormalPrompt()
+    {
+        var handler = new TestPixHandler();
+        var invoice = new InvoiceEntity
+        {
+            Id = "invoice-prompt-normal-clears-p2p-details",
+            Currency = "BRL",
+            Price = 12.34m,
+            Status = InvoiceStatus.New
+        };
+        var context = new PaymentMethodContext(
+            new BTCPayServer.Data.StoreData { Id = "store-prompt-normal-clears-p2p-details" },
+            new StoreBlob(),
+            new JObject(),
+            handler,
+            invoice,
+            new InvoiceLogs());
+        var service = new DepixService(null!, null!, null!, null!, null!, null!, null!, null!, null!);
+
+        service.ApplyPromptDetails(
+            context,
+            new DepixDepositResponse("qr-p2p-details", "https://example.invalid/qr-p2p.png", "copy-paste-p2p"),
+            "buyer-depix-address",
+            1234,
+            p2PMode: true,
+            depixSplitAddress: "fresh-store-commission-address",
+            p2PCommissionPercent: "5%");
+
+        service.ApplyPromptDetails(
+            context,
+            new DepixDepositResponse("qr-normal-details", "https://example.invalid/qr-normal.png", "copy-paste-normal"),
+            "store-depix-address",
+            1234);
+
+        var details = Assert.IsType<DePixPaymentMethodDetails>(handler.ParsePaymentPromptDetails(context.Prompt.Details));
+        Assert.Null(details.P2PMode);
+        Assert.Null(details.DepixSplitAddress);
+        Assert.Null(details.P2PCommissionPercent);
+        Assert.Null(details.SplitFee);
+        Assert.Equal("store-depix-address", details.DepixAddress);
+        Assert.Equal("qr-normal-details", details.QrId);
+    }
+
+    [Fact]
+    public void RestrictInvoiceToPixIfP2PKeepsOnlyPixPrompt()
+    {
+        var invoice = new InvoiceEntity
+        {
+            Id = "invoice-p2p-restrict-payment-methods",
+            Currency = "BRL",
+            Price = 12.34m,
+            Status = InvoiceStatus.New
+        };
+        invoice.AddRate(new CurrencyPair("BRL", "BRL"), 1m);
+        var pixPrompt = new PaymentPrompt
+        {
+            PaymentMethodId = PixPmid,
+            Currency = "BRL",
+            Divisibility = 2,
+            Destination = "https://example.invalid/pix.png",
+            Details = JToken.FromObject(new DePixPaymentMethodDetails
+            {
+                QrId = "qr-p2p-restrict",
+                P2PMode = true
+            })
+        };
+        var bitcoinPrompt = new PaymentPrompt
+        {
+            PaymentMethodId = PaymentTypes.CHAIN.GetPaymentMethodId("BTC"),
+            Currency = "BRL",
+            Divisibility = 2,
+            Destination = "bitcoin-address",
+            Details = new JObject()
+        };
+        invoice.SetPaymentPrompts(new PaymentPromptDictionary([pixPrompt, bitcoinPrompt]));
+
+        Assert.True(P2PInvoicePaymentMethodRestrictor.TryRestrictInvoiceToPixIfP2P(invoice));
+
+        var prompt = Assert.Single(invoice.GetPaymentPrompts());
+        Assert.Equal(PixPmid, prompt.PaymentMethodId);
+    }
+
+    [Fact]
+    public async Task RequestDepositUsesConfiguredSplitWhenNoOverrideIsProvided()
+    {
+        var capture = new CaptureDepositRequestHandler();
+        using var client = new HttpClient(capture) { BaseAddress = new Uri("https://example.invalid/api/") };
+        var service = new DepixService(null!, null!, null!, null!, null!, null!, null!, null!, null!);
+
+        await service.RequestDepositAsync(
+            client,
+            10000,
+            "merchant-depix-address",
+            new PixPaymentMethodConfig
+            {
+                DepixSplitAddress = "configured-split-address",
+                SplitFee = "3%"
+            },
+            useWhitelist: true,
+            CancellationToken.None);
+
+        var payload = JObject.Parse(capture.Body!);
+        Assert.Equal(10000, payload.Value<int>("amountInCents"));
+        Assert.Equal("merchant-depix-address", payload.Value<string>("depixAddress"));
+        Assert.Equal("configured-split-address", payload.Value<string>("depixSplitAddress"));
+        Assert.Equal("3%", payload.Value<string>("splitFee"));
+        Assert.True(payload.Value<bool>("whitelist"));
+    }
+
+    [Fact]
+    public async Task RequestDepositDoesNotSendConfiguredSplitFeeWithoutConfiguredSplitAddress()
+    {
+        var capture = new CaptureDepositRequestHandler();
+        using var client = new HttpClient(capture) { BaseAddress = new Uri("https://example.invalid/api/") };
+        var service = new DepixService(null!, null!, null!, null!, null!, null!, null!, null!, null!);
+
+        await service.RequestDepositAsync(
+            client,
+            10000,
+            "merchant-depix-address",
+            new PixPaymentMethodConfig
+            {
+                P2PMode = true,
+                P2PCommissionPercent = "5%"
+            },
+            useWhitelist: false,
+            CancellationToken.None);
+
+        var payload = JObject.Parse(capture.Body!);
+        Assert.Equal("merchant-depix-address", payload.Value<string>("depixAddress"));
+        Assert.False(payload.ContainsKey("depixSplitAddress"));
+        Assert.False(payload.ContainsKey("splitFee"));
+    }
+
+    [Fact]
+    public async Task RequestDepositUsesP2PGeneratedSplitOverride()
+    {
+        var capture = new CaptureDepositRequestHandler();
+        using var client = new HttpClient(capture) { BaseAddress = new Uri("https://example.invalid/api/") };
+        var service = new DepixService(null!, null!, null!, null!, null!, null!, null!, null!, null!);
+
+        await service.RequestDepositAsync(
+            client,
+            10000,
+            "buyer-depix-address",
+            new PixPaymentMethodConfig
+            {
+                DepixSplitAddress = "configured-split-address",
+                SplitFee = "3%"
+            },
+            useWhitelist: false,
+            CancellationToken.None,
+            depixSplitAddressOverride: "fresh-store-commission-address",
+            splitFeeOverride: "5%");
+
+        var payload = JObject.Parse(capture.Body!);
+        Assert.Equal("buyer-depix-address", payload.Value<string>("depixAddress"));
+        Assert.Equal("fresh-store-commission-address", payload.Value<string>("depixSplitAddress"));
+        Assert.Equal("5%", payload.Value<string>("splitFee"));
+        Assert.False(payload.ContainsKey("whitelist"));
+    }
+
+    [Fact]
+    public async Task RequestDepositIncludesDepixApiErrorBody()
+    {
+        var capture = new CaptureDepositRequestHandler(
+            HttpStatusCode.BadRequest,
+            """{"error":"invalid depixSplitAddress"}""");
+        using var client = new HttpClient(capture) { BaseAddress = new Uri("https://example.invalid/api/") };
+        var service = new DepixService(null!, null!, null!, null!, null!, null!, null!, null!, null!);
+
+        var ex = await Assert.ThrowsAsync<PaymentMethodUnavailableException>(() =>
+            service.RequestDepositAsync(
+                client,
+                10000,
+                "buyer-depix-address",
+                new PixPaymentMethodConfig(),
+                useWhitelist: false,
+                CancellationToken.None));
+
+        Assert.Contains("400", ex.Message);
+        Assert.Contains("invalid depixSplitAddress", ex.Message);
+    }
+
+    [Fact]
+    public void P2PDestinationAddressRejectsNonStringMetadataAsUnavailable()
+    {
+        var handler = RuntimeHelpers.GetUninitializedObject(typeof(PixPaymentMethodHandler));
+        var method = typeof(PixPaymentMethodHandler).GetMethod("TryGetP2PDestinationAddress", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var invoice = new InvoiceEntity
+        {
+            Id = "invoice-p2p-non-string-metadata",
+            Currency = "BRL",
+            Price = 12.34m,
+            Status = InvoiceStatus.New,
+            Metadata = new InvoiceMetadata
+            {
+                AdditionalData = new Dictionary<string, JToken>
+                {
+                    ["depixAddress"] = new JValue(123)
+                }
+            }
+        };
+        var context = new PaymentMethodContext(
+            new BTCPayServer.Data.StoreData { Id = "store-p2p-non-string-metadata" },
+            new StoreBlob(),
+            new JObject(),
+            new TestPixHandler(),
+            invoice,
+            new InvoiceLogs());
+
+        object?[] args = [context, null];
+        var ex = Assert.Throws<TargetInvocationException>(() => method.Invoke(handler, args));
+        Assert.IsType<PaymentMethodUnavailableException>(ex.InnerException);
+    }
+
+    [Fact]
+    public void P2PDestinationAddressReadsPendingPosFormResponse()
+    {
+        var method = typeof(PixPaymentMethodHandler).GetMethod(
+            "TryGetP2PDestinationAddress",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        object?[] args =
+        [
+            null,
+            """{"depixAddress":" buyer-depix-address "}""",
+            null
+        ];
+
+        var found = Assert.IsType<bool>(method.Invoke(null, args));
+
+        Assert.True(found);
+        Assert.Equal("buyer-depix-address", args[2]);
+    }
+
+    [Fact]
+    public void P2PDestinationAddressPrefersInvoiceMetadataOverPendingPosFormResponse()
+    {
+        var method = typeof(PixPaymentMethodHandler).GetMethod(
+            "TryGetP2PDestinationAddress",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        object?[] args =
+        [
+            new Dictionary<string, JToken>
+            {
+                ["depixAddress"] = "metadata-depix-address"
+            },
+            """{"depixAddress":"form-depix-address"}""",
+            null
+        ];
+
+        var found = Assert.IsType<bool>(method.Invoke(null, args));
+
+        Assert.True(found);
+        Assert.Equal("metadata-depix-address", args[2]);
+    }
+
     private sealed class TestPixHandler : IPaymentMethodHandler
     {
         public PaymentMethodId PaymentMethodId => PixPmid;
@@ -76,6 +404,30 @@ public class PixPaymentMethodHandlerTests
         public object ParsePaymentDetails(JToken details)
         {
             return details.ToObject<DePixPaymentData>(Serializer)!;
+        }
+    }
+
+    private sealed class CaptureDepositRequestHandler(
+        HttpStatusCode statusCode = HttpStatusCode.OK,
+        string responseBody = """
+                              {
+                                "response": {
+                                  "id": "qr-id",
+                                  "qrImageUrl": "https://example.invalid/qr.png",
+                                  "qrCopyPaste": "copy-paste"
+                                }
+                              }
+                              """) : HttpMessageHandler
+    {
+        public string? Body { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Body = request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
+            return new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(responseBody)
+            };
         }
     }
 }

--- a/BTCPayServer.Plugins.Depix.Tests/PixPaymentMethodHandlerTests.cs
+++ b/BTCPayServer.Plugins.Depix.Tests/PixPaymentMethodHandlerTests.cs
@@ -330,7 +330,8 @@ public class PixPaymentMethodHandlerTests
 
         object?[] args = [context, null];
         var ex = Assert.Throws<TargetInvocationException>(() => method.Invoke(handler, args));
-        Assert.IsType<PaymentMethodUnavailableException>(ex.InnerException);
+        var unavailable = Assert.IsType<PaymentMethodUnavailableException>(ex.InnerException);
+        Assert.Equal("P2P mode requires a DePix address", unavailable.Message);
     }
 
     [Fact]
@@ -374,6 +375,25 @@ public class PixPaymentMethodHandlerTests
 
         Assert.True(found);
         Assert.Equal("metadata-depix-address", args[2]);
+    }
+
+    [Fact]
+    public void P2PDestinationAddressRejectsNonStringFormResponseAsUnavailable()
+    {
+        var method = typeof(PixPaymentMethodHandler).GetMethod(
+            "TryGetP2PDestinationAddress",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        object?[] args =
+        [
+            null,
+            """{"depixAddress":123}""",
+            null
+        ];
+
+        var ex = Assert.Throws<TargetInvocationException>(() => method.Invoke(null, args));
+        var unavailable = Assert.IsType<PaymentMethodUnavailableException>(ex.InnerException);
+        Assert.Equal("P2P mode requires a DePix address", unavailable.Message);
     }
 
     private sealed class TestPixHandler : IPaymentMethodHandler

--- a/BTCPayServer.Plugins.Depix.Tests/PixSettingsTests.cs
+++ b/BTCPayServer.Plugins.Depix.Tests/PixSettingsTests.cs
@@ -1,4 +1,11 @@
 using System.Threading.Tasks;
+using System.Linq;
+using BTCPayServer.Abstractions.Form;
+using BTCPayServer.Abstractions.Models;
+using BTCPayServer.Data;
+using BTCPayServer.Forms;
+using BTCPayServer.Plugins.PointOfSale;
+using BTCPayServer.Services.Apps;
 using BTCPayServer.Tests;
 using Microsoft.Playwright;
 using Xunit;
@@ -37,6 +44,7 @@ public class PixSettingsTests : PlaywrightBaseTest
         await GoToPixSettingsAsync();
 
         await Page.Locator("#IsEnabled").SetCheckedAsync(true);
+        await Page.GetByText("Payment options").ClickAsync();
         await Page.Locator("#PassFeeToCustomer").SetCheckedAsync(true);
         await Page.Locator("#UseWhitelist").SetCheckedAsync(true);
         await Page.GetByRole(AriaRole.Button, new() { Name = "Save" }).ClickAsync();
@@ -44,8 +52,125 @@ public class PixSettingsTests : PlaywrightBaseTest
         await Tester.FindAlertMessage(partialText: "Pix configuration applied");
 
         Assert.True(await Page.Locator("#IsEnabled").IsCheckedAsync());
+        await Page.GetByText("Payment options").ClickAsync();
         Assert.True(await Page.Locator("#PassFeeToCustomer").IsCheckedAsync());
         Assert.True(await Page.Locator("#UseWhitelist").IsCheckedAsync());
+    }
+
+    [Fact(Timeout = TestUtils.TestTimeout)]
+    [Trait("Category", "PlaywrightUITest")]
+    public async Task CanSaveP2PModeAndCreateIndependentP2PPointOfSale()
+    {
+        await InitializeStoreOwnerAsync();
+        await SeedValidStorePixConfigAsync(
+            depixSplitAddress: "saved-normal-split-address",
+            splitFee: "2%");
+        var appService = Server.PayTester.GetService<AppService>();
+        var normalPos = new AppData
+        {
+            StoreDataId = Tester.StoreId!,
+            Name = "Normal POS",
+            AppType = PointOfSaleAppType.AppType
+        };
+        normalPos.SetSettings(new PointOfSaleSettings
+        {
+            Title = "Normal POS",
+            Currency = "BRL"
+        });
+        await appService.UpdateOrCreateApp(normalPos);
+
+        await GoToPixSettingsAsync();
+
+        await Page.GetByText("P2P mode", new() { Exact = true }).ClickAsync();
+        await Page.Locator("#P2PMode").SetCheckedAsync(true);
+        await Page.Locator("#P2PCommissionPercent").FillAsync("5");
+        await Page.GetByRole(AriaRole.Button, new() { Name = "Save" }).ClickAsync();
+
+        await Tester.FindAlertMessage(partialText: "DePix P2P POS app was created");
+
+        var storeConfig = await GetStorePixConfigAsync();
+        Assert.NotNull(storeConfig);
+        Assert.True(storeConfig!.P2PMode);
+        Assert.Equal("5%", storeConfig.P2PCommissionPercent);
+        Assert.Equal("2%", storeConfig.SplitFee);
+        Assert.Equal("saved-normal-split-address", storeConfig.DepixSplitAddress);
+
+        Assert.Equal(0, await Page.GetByRole(AriaRole.Heading, new() { Name = "Pix", Exact = true }).CountAsync());
+        Assert.Equal(0, await Page.GetByRole(AriaRole.Heading, new() { Name = "Normal Pix" }).CountAsync());
+        await Page.GetByText("Split", new() { Exact = true }).WaitForAsync();
+        await Page.GetByText("P2P mode", new() { Exact = true }).ClickAsync();
+        await Page.GetByText("P2P commission (%)").WaitForAsync();
+        await Page.GetByText("Split", new() { Exact = true }).ClickAsync();
+        await Page.GetByText("DePix address that receives the split portion", new() { Exact = false }).WaitForAsync();
+        await Page.GetByText("Percentage of each regular Pix payment", new() { Exact = false }).WaitForAsync();
+        Assert.Null(await Page.Locator("#DepixSplitAddress").GetAttributeAsync("readonly"));
+
+        var apps = (await appService.GetApps(PointOfSaleAppType.AppType))
+            .Where(app => app.StoreDataId == Tester.StoreId)
+            .ToList();
+        var persistedNormalPos = Assert.Single(apps, app => app.Name == "Normal POS");
+        Assert.True(string.IsNullOrEmpty(persistedNormalPos.GetSettings<PointOfSaleSettings>().FormId));
+
+        var p2PPos = Assert.Single(apps, app => app.Name == "DePix P2P");
+        var p2PPosSettings = p2PPos.GetSettings<PointOfSaleSettings>();
+        Assert.Equal("BRL", p2PPosSettings.Currency);
+        Assert.Equal(PosViewType.Light, p2PPosSettings.DefaultView);
+        Assert.True(p2PPosSettings.ShowCustomAmount);
+        Assert.False(p2PPosSettings.ShowItems);
+        Assert.False(string.IsNullOrEmpty(p2PPosSettings.FormId));
+
+        var formDataService = Server.PayTester.GetService<FormDataService>();
+        var formData = await formDataService.GetForm(Tester.StoreId!, p2PPosSettings.FormId);
+        Assert.NotNull(formData);
+        var form = Form.Parse(formData!.Config);
+        var depixAddressField = form.GetFieldByFullName("depixAddress");
+        Assert.NotNull(depixAddressField);
+        Assert.True(depixAddressField!.Required);
+    }
+
+    [Fact(Timeout = TestUtils.TestTimeout)]
+    [Trait("Category", "PlaywrightUITest")]
+    public async Task CanDisableP2PWithoutNormalSplit()
+    {
+        await InitializeStoreOwnerAsync();
+        await SeedValidStorePixConfigAsync(
+            p2PMode: true,
+            p2PCommissionPercent: "5.0%");
+        await GoToPixSettingsAsync();
+
+        await Page.GetByText("P2P mode", new() { Exact = true }).ClickAsync();
+        await Page.Locator("#P2PMode").SetCheckedAsync(false);
+        await Page.GetByRole(AriaRole.Button, new() { Name = "Save" }).ClickAsync();
+
+        await Tester.FindAlertMessage(partialText: "Pix configuration applied");
+
+        var storeConfig = await GetStorePixConfigAsync();
+        Assert.NotNull(storeConfig);
+        Assert.False(storeConfig!.P2PMode);
+        Assert.Equal("5%", storeConfig.P2PCommissionPercent);
+        Assert.Null(storeConfig.SplitFee);
+        Assert.Null(storeConfig.DepixSplitAddress);
+    }
+
+    [Fact(Timeout = TestUtils.TestTimeout)]
+    [Trait("Category", "PlaywrightUITest")]
+    public async Task RequiresP2PCommissionWhenP2PEnabled()
+    {
+        await InitializeStoreOwnerAsync();
+        await SeedValidStorePixConfigAsync();
+        await GoToPixSettingsAsync();
+
+        await Page.GetByText("P2P mode", new() { Exact = true }).ClickAsync();
+        await Page.Locator("#P2PMode").SetCheckedAsync(true);
+        await Page.Locator("#P2PCommissionPercent").FillAsync("");
+        await Page.GetByRole(AriaRole.Button, new() { Name = "Save" }).ClickAsync();
+
+        await Tester.FindAlertMessage(StatusMessageModel.StatusSeverity.Error, "P2P commission is required in P2P mode");
+
+        var storeConfig = await GetStorePixConfigAsync();
+        Assert.NotNull(storeConfig);
+        Assert.False(storeConfig!.P2PMode);
+        Assert.Null(storeConfig.P2PCommissionPercent);
     }
 
     [Fact(Timeout = TestUtils.TestTimeout)]
@@ -56,7 +181,7 @@ public class PixSettingsTests : PlaywrightBaseTest
         await SeedValidServerPixConfigAsync();
         await GoToPixSettingsAsync();
 
-        await Page.GetByText("server-level DePix Api Key configuration", new() { Exact = false }).WaitForAsync();
+        await Page.GetByText("Server-level DePix configuration", new() { Exact = false }).WaitForAsync();
         Assert.Equal(0, await Page.Locator("#PassFeeToCustomer").CountAsync());
         Assert.Equal(0, await Page.Locator("#UseWhitelist").CountAsync());
 

--- a/BTCPayServer.Plugins.Depix.Tests/PixSettingsTests.cs
+++ b/BTCPayServer.Plugins.Depix.Tests/PixSettingsTests.cs
@@ -175,6 +175,94 @@ public class PixSettingsTests : PlaywrightBaseTest
 
     [Fact(Timeout = TestUtils.TestTimeout)]
     [Trait("Category", "PlaywrightUITest")]
+    public async Task RejectsInvalidP2PCommissionValues()
+    {
+        await InitializeStoreOwnerAsync();
+        await SeedValidStorePixConfigAsync();
+        await GoToPixSettingsAsync();
+
+        foreach (var invalidCommission in new[] { "0", "100", "5.123", "five" })
+        {
+            await Page.GetByText("P2P mode", new() { Exact = true }).ClickAsync();
+            await Page.Locator("#P2PMode").SetCheckedAsync(true);
+            await Page.Locator("#P2PCommissionPercent").FillAsync(invalidCommission);
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Save" }).ClickAsync();
+
+            await Tester.FindAlertMessage(
+                StatusMessageModel.StatusSeverity.Error,
+                "P2P commission must be greater than 0 and less than 100, with up to 2 decimal places.");
+
+            var storeConfig = await GetStorePixConfigAsync();
+            Assert.NotNull(storeConfig);
+            Assert.False(storeConfig!.P2PMode);
+            Assert.Null(storeConfig.P2PCommissionPercent);
+        }
+    }
+
+    [Fact(Timeout = TestUtils.TestTimeout)]
+    [Trait("Category", "PlaywrightUITest")]
+    public async Task RepairsExistingP2PFormAndUpdatesExistingP2PPointOfSale()
+    {
+        await InitializeStoreOwnerAsync();
+        await SeedValidStorePixConfigAsync();
+
+        var formDataService = Server.PayTester.GetService<FormDataService>();
+        var customForm = new Form();
+        customForm.Fields.Add(Field.Create(
+            "Customer note",
+            "customerNote",
+            null,
+            false,
+            "Optional note."));
+        var brokenForm = new FormData
+        {
+            StoreId = Tester.StoreId!,
+            Name = "DePix P2P checkout",
+            Config = customForm.ToString()
+        };
+        await formDataService.AddOrUpdateForm(brokenForm);
+
+        var appService = Server.PayTester.GetService<AppService>();
+        var p2PPos = new AppData
+        {
+            StoreDataId = Tester.StoreId!,
+            Name = "DePix P2P",
+            AppType = PointOfSaleAppType.AppType
+        };
+        p2PPos.SetSettings(new PointOfSaleSettings
+        {
+            Title = "DePix P2P",
+            Currency = "BRL",
+            FormId = "stale-form-id"
+        });
+        await appService.UpdateOrCreateApp(p2PPos);
+
+        await GoToPixSettingsAsync();
+
+        await Page.GetByText("P2P mode", new() { Exact = true }).ClickAsync();
+        await Page.Locator("#P2PMode").SetCheckedAsync(true);
+        await Page.Locator("#P2PCommissionPercent").FillAsync("5");
+        await Page.GetByRole(AriaRole.Button, new() { Name = "Save" }).ClickAsync();
+
+        await Tester.FindAlertMessage(partialText: "DePix P2P POS app was updated");
+
+        var forms = await formDataService.GetForms(Tester.StoreId!);
+        var repairedForm = Assert.Single(forms, form => form.Name == "DePix P2P checkout");
+        var parsedForm = Form.Parse(repairedForm.Config);
+        var depixAddressField = parsedForm.GetFieldByFullName("depixAddress");
+        Assert.NotNull(depixAddressField);
+        Assert.True(depixAddressField!.Required);
+        Assert.NotNull(parsedForm.GetFieldByFullName("customerNote"));
+
+        var apps = (await appService.GetApps(PointOfSaleAppType.AppType))
+            .Where(app => app.StoreDataId == Tester.StoreId && app.Name == "DePix P2P")
+            .ToList();
+        var updatedP2PPos = Assert.Single(apps);
+        Assert.Equal(repairedForm.Id, updatedP2PPos.GetSettings<PointOfSaleSettings>().FormId);
+    }
+
+    [Fact(Timeout = TestUtils.TestTimeout)]
+    [Trait("Category", "PlaywrightUITest")]
     public async Task CanEnablePixUsingServerLevelConfiguration()
     {
         await InitializeStoreOwnerAsync();

--- a/BTCPayServer.Plugins.Depix.Tests/PixTransactionsTests.cs
+++ b/BTCPayServer.Plugins.Depix.Tests/PixTransactionsTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Threading.Tasks;
+using BTCPayServer.Data;
+using BTCPayServer.Logging;
+using BTCPayServer.Payments;
+using BTCPayServer.Plugins.Depix.PaymentHandlers;
+using BTCPayServer.Rating;
+using BTCPayServer.Services.Invoices;
+using BTCPayServer.Services.Stores;
+using BTCPayServer.Tests;
+using Microsoft.Playwright;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace BTCPayServer.Plugins.Depix.Tests;
+
+[Collection(SharedPluginTestCollection.CollectionName)]
+public class PixTransactionsTests : PlaywrightBaseTest
+{
+    private static readonly PaymentMethodId PixPmid = new("PIX");
+
+    public PixTransactionsTests(SharedPluginTestFixture fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+
+    [Fact(Timeout = TestUtils.TestTimeout)]
+    [Trait("Category", "PlaywrightUITest")]
+    public async Task ShowsP2PCommissionDetailsOnTransactionsPage()
+    {
+        await InitializeStoreOwnerAsync();
+        await SeedValidStorePixConfigAsync(
+            isEnabled: true,
+            p2PMode: true,
+            p2PCommissionPercent: "5%");
+
+        var invoice = await CreateP2PPixInvoiceAsync(
+            qrId: "qr-p2p-transactions",
+            depixAddress: "buyer-depix-address",
+            depixSplitAddress: "fresh-store-commission-address",
+            p2PCommissionPercent: "5%");
+
+        await Tester.GoToUrl($"/stores/{Tester.StoreId}/pix/transactions");
+
+        var row = Page.Locator("#DepixTransactions tbody tr").Filter(new() { HasText = invoice.Id });
+        await row.GetByText(invoice.Id).WaitForAsync();
+        await row.GetByText("qr-p2p-transactions").WaitForAsync();
+        await row.GetByText("P2P", new() { Exact = true }).WaitForAsync();
+        await row.GetByText("buyer-depix-address").WaitForAsync();
+        await row.GetByText("5%").WaitForAsync();
+        await row.GetByText("fresh-store-commission-address").WaitForAsync();
+    }
+
+    private async Task<InvoiceEntity> CreateP2PPixInvoiceAsync(
+        string qrId,
+        string depixAddress,
+        string depixSplitAddress,
+        string p2PCommissionPercent)
+    {
+        var storeRepository = Server.PayTester.GetService<StoreRepository>();
+        var handlers = Server.PayTester.GetService<PaymentMethodHandlerDictionary>();
+        var handler = handlers[PixPmid];
+        var invoiceRepository = Server.PayTester.InvoiceRepository;
+        var store = await storeRepository.FindStore(Tester.StoreId!)
+                    ?? throw new InvalidOperationException("Store not found.");
+
+        var invoice = invoiceRepository.CreateNewInvoice(Tester.StoreId!);
+        invoice.Currency = "BRL";
+        invoice.Price = 12.34m;
+        invoice.AddRate(new CurrencyPair("BRL", "BRL"), 1m);
+        invoice.SetPaymentPrompt(PixPmid, new PaymentPrompt
+        {
+            Currency = "BRL",
+            Divisibility = 2,
+            Destination = "https://example.invalid/pix.png",
+            Details = JToken.FromObject(new DePixPaymentMethodDetails
+            {
+                QrId = qrId,
+                DepixAddress = depixAddress,
+                P2PMode = true,
+                DepixSplitAddress = depixSplitAddress,
+                P2PCommissionPercent = p2PCommissionPercent,
+                Status = "pending",
+                ValueInCents = 1234
+            }, handler.Serializer)
+        });
+
+        await invoiceRepository.CreateInvoiceAsync(new InvoiceCreationContext(
+            store,
+            store.GetStoreBlob(),
+            invoice,
+            new InvoiceLogs(),
+            handlers,
+            invoicePaymentMethodFilter: null));
+
+        return invoice;
+    }
+}

--- a/BTCPayServer.Plugins.Depix.Tests/PlaywrightBaseTest.cs
+++ b/BTCPayServer.Plugins.Depix.Tests/PlaywrightBaseTest.cs
@@ -76,7 +76,11 @@ public abstract class PlaywrightBaseTest : IAsyncLifetime
     protected async Task SeedValidStorePixConfigAsync(
         bool isEnabled = false,
         bool useWhitelist = false,
-        bool passFeeToCustomer = false)
+        bool passFeeToCustomer = false,
+        bool p2PMode = false,
+        string? p2PCommissionPercent = null,
+        string? depixSplitAddress = null,
+        string? splitFee = null)
     {
         var storeId = Tester.StoreId ?? throw new InvalidOperationException("Create a store before seeding Pix configuration.");
         var storeRepository = Server.PayTester.GetService<StoreRepository>();
@@ -89,8 +93,15 @@ public abstract class PlaywrightBaseTest : IAsyncLifetime
             ["webhookSecretHashHex"] = ComputeSecretHash("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
             ["isEnabled"] = isEnabled,
             ["useWhitelist"] = useWhitelist,
-            ["passFeeToCustomer"] = passFeeToCustomer
+            ["passFeeToCustomer"] = passFeeToCustomer,
+            ["p2PMode"] = p2PMode
         };
+        if (p2PCommissionPercent is not null)
+            config["p2PCommissionPercent"] = p2PCommissionPercent;
+        if (depixSplitAddress is not null)
+            config["depixSplitAddress"] = depixSplitAddress;
+        if (splitFee is not null)
+            config["splitFee"] = splitFee;
 
         store.SetPaymentMethodConfig(PixPaymentMethodId, config);
 
@@ -118,7 +129,13 @@ public abstract class PlaywrightBaseTest : IAsyncLifetime
             config.Value<string>("webhookSecretHashHex") ?? config.Value<string>("WebhookSecretHashHex"),
             config.Value<bool?>("isEnabled") ?? config.Value<bool?>("IsEnabled") ?? false,
             config.Value<bool?>("useWhitelist") ?? config.Value<bool?>("UseWhitelist") ?? false,
-            config.Value<bool?>("passFeeToCustomer") ?? config.Value<bool?>("PassFeeToCustomer") ?? false);
+            config.Value<bool?>("passFeeToCustomer") ?? config.Value<bool?>("PassFeeToCustomer") ?? false,
+            config.Value<bool?>("p2PMode") ?? config.Value<bool?>("P2PMode") ?? false,
+            config.Value<string>("p2PCommissionPercent") ??
+            config.Value<string>("p2pCommissionPercent") ??
+            config.Value<string>("P2PCommissionPercent"),
+            config.Value<string>("depixSplitAddress") ?? config.Value<string>("DepixSplitAddress"),
+            config.Value<string>("splitFee") ?? config.Value<string>("SplitFee"));
     }
 
     protected async Task SeedValidServerPixConfigAsync(
@@ -189,5 +206,9 @@ public abstract class PlaywrightBaseTest : IAsyncLifetime
         string? WebhookSecretHashHex,
         bool IsEnabled,
         bool UseWhitelist,
-        bool PassFeeToCustomer);
+        bool PassFeeToCustomer,
+        bool P2PMode,
+        string? P2PCommissionPercent,
+        string? DepixSplitAddress,
+        string? SplitFee);
 }

--- a/BTCPayServer.Plugins.Depix/Controllers/PixController.cs
+++ b/BTCPayServer.Plugins.Depix/Controllers/PixController.cs
@@ -1,15 +1,20 @@
 #nullable enable
 using System;
-using System.Globalization;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Constants;
+using BTCPayServer.Abstractions.Form;
 using BTCPayServer.Client;
+using BTCPayServer.Client.Models;
 using BTCPayServer.Data;
+using BTCPayServer.Forms;
 using BTCPayServer.Plugins.Depix.Data.Models;
 using BTCPayServer.Plugins.Depix.Data.Models.ViewModels;
 using BTCPayServer.Plugins.Depix.PaymentHandlers;
 using BTCPayServer.Plugins.Depix.Services;
+using BTCPayServer.Plugins.PointOfSale;
+using BTCPayServer.Services.Apps;
 using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Stores;
 using Microsoft.AspNetCore.Authorization;
@@ -27,9 +32,14 @@ public class PixController(
     StoreRepository storeRepository,
     PaymentMethodHandlerDictionary handlers,
     ISecretProtector protector,
-    DepixService depixService)
+    DepixService depixService,
+    FormDataService formDataService,
+    AppService appService)
     : Controller
 {
+    private const string P2PDepixAddressFieldName = "depixAddress";
+    private const string P2PDefaultFormName = "DePix P2P checkout";
+    private const string P2PDefaultPosName = "DePix P2P";
     private StoreData StoreData => HttpContext.GetStoreData();
     
     /// <summary>
@@ -80,6 +90,8 @@ public class PixController(
             ApiKey = maskedApiKey,
             UseWhitelist = cfg is { UseWhitelist: true },
             PassFeeToCustomer = cfg is { PassFeeToCustomer: true },
+            P2PMode = cfg is { P2PMode: true },
+            P2PCommissionPercent = cfg?.P2PCommissionPercent,
             DepixSplitAddress = cfg?.DepixSplitAddress,
             SplitFee = cfg?.SplitFee,
             WebhookUrl = webhookUrl,
@@ -125,21 +137,24 @@ public class PixController(
 
         var splitAddress = viewModel.DepixSplitAddress?.Trim();
         var splitFeeRaw = viewModel.SplitFee?.Trim();
+        var p2PCommissionRaw = viewModel.P2PCommissionPercent?.Trim();
         var hasSplitAddress = !string.IsNullOrWhiteSpace(splitAddress);
         var hasSplitFee = !string.IsNullOrWhiteSpace(splitFeeRaw);
+        var hasP2PCommission = !string.IsNullOrWhiteSpace(p2PCommissionRaw);
+
         if (hasSplitAddress ^ hasSplitFee)
         {
             TempData[WellKnownTempData.ErrorMessage] = "Split Fee and DePix Split Address must be provided together.";
             return RedirectToAction(nameof(PixSettings), new { walletId });
         }
-
-        if (hasSplitFee)
+        else if (hasSplitFee)
         {
-            if (!TryNormalizeSplitFee(splitFeeRaw!, out var normalizedSplitFee))
+            if (!DepixService.TryNormalizeSplitFee(splitFeeRaw!, out var normalizedSplitFee))
             {
                 TempData[WellKnownTempData.ErrorMessage] = "Split Fee must be greater than 0 and less than 100, with up to 2 decimal places.";
                 return RedirectToAction(nameof(PixSettings), new { walletId });
             }
+
             viewModel.SplitFee = normalizedSplitFee;
             viewModel.DepixSplitAddress = splitAddress;
         }
@@ -147,6 +162,26 @@ public class PixController(
         {
             viewModel.SplitFee = null;
             viewModel.DepixSplitAddress = null;
+        }
+
+        if (hasP2PCommission)
+        {
+            if (!DepixService.TryNormalizeSplitFee(p2PCommissionRaw!, out var normalizedP2PCommission))
+            {
+                TempData[WellKnownTempData.ErrorMessage] = "P2P commission must be greater than 0 and less than 100, with up to 2 decimal places.";
+                return RedirectToAction(nameof(PixSettings), new { walletId });
+            }
+
+            viewModel.P2PCommissionPercent = normalizedP2PCommission;
+        }
+        else if (viewModel.P2PMode)
+        {
+            TempData[WellKnownTempData.ErrorMessage] = "P2P commission is required in P2P mode.";
+            return RedirectToAction(nameof(PixSettings), new { walletId });
+        }
+        else
+        {
+            viewModel.P2PCommissionPercent = null;
         }
         
         string? oneShotSecretToDisplay = null;
@@ -174,6 +209,8 @@ public class PixController(
         cfg.IsEnabled = willEnable;
         cfg.UseWhitelist = viewModel.UseWhitelist;
         cfg.PassFeeToCustomer = viewModel.PassFeeToCustomer;
+        cfg.P2PMode = viewModel.P2PMode;
+        cfg.P2PCommissionPercent = viewModel.P2PCommissionPercent;
         cfg.DepixSplitAddress = viewModel.DepixSplitAddress;
         cfg.SplitFee = viewModel.SplitFee;
         store.SetPaymentMethodConfig(handlers[pmid], cfg);
@@ -182,30 +219,141 @@ public class PixController(
 
         await storeRepository.UpdateStore(store);
 
+        var p2PPosSetup = viewModel.P2PMode
+            ? await EnsureP2PPointOfSaleAsync(store.Id)
+            : null;
+
         if (!string.IsNullOrEmpty(oneShotSecretToDisplay))
             TempData["OneShotSecret"] = oneShotSecretToDisplay;
 
-        TempData[WellKnownTempData.SuccessMessage] = "Pix configuration applied";
+        TempData[WellKnownTempData.SuccessMessage] = p2PPosSetup is { PosAppCreated: true }
+            ? "Pix configuration applied. DePix P2P POS app was created."
+            : p2PPosSetup is { PosAppUpdated: true }
+                ? "Pix configuration applied. DePix P2P POS app was updated."
+            : viewModel.P2PMode
+                ? "Pix configuration applied. DePix P2P POS app is ready."
+                : "Pix configuration applied";
         return RedirectToAction(nameof(PixSettings), new { storeId = StoreData.Id, walletId });
     }
 
-    private static bool TryNormalizeSplitFee(string raw, out string normalized)
+    private async Task<P2PPosSetupResult> EnsureP2PPointOfSaleAsync(string storeId)
     {
-        normalized = "";
-        var trimmed = raw.Trim();
-        if (trimmed.EndsWith("%", StringComparison.Ordinal))
-            trimmed = trimmed[..^1].Trim();
-        if (!decimal.TryParse(trimmed, NumberStyles.Number, CultureInfo.InvariantCulture, out var value))
-            return false;
-        if (value <= 0m || value >= 100m)
-            return false;
-        var scale = (decimal.GetBits(value)[3] >> 16) & 0xFF;
-        if (scale > 2)
-            return false;
-        normalized = value.ToString("0.##", CultureInfo.InvariantCulture) + "%";
-        return true;
+        var defaultFormId = await EnsureDefaultP2PFormAsync(storeId);
+        var posApps = (await appService.GetApps(PointOfSaleAppType.AppType))
+            .Where(app => app.StoreDataId == storeId && !app.Archived)
+            .ToList();
+
+        if (posApps.Any(app => string.Equals(app.GetSettings<PointOfSaleSettings>().FormId, defaultFormId, StringComparison.Ordinal)))
+            return new P2PPosSetupResult(defaultFormId, false, false);
+
+        var existingP2PPos = posApps.FirstOrDefault(app => string.Equals(app.Name, P2PDefaultPosName, StringComparison.Ordinal));
+        if (existingP2PPos is not null)
+        {
+            var settings = existingP2PPos.GetSettings<PointOfSaleSettings>();
+            settings.FormId = defaultFormId;
+            existingP2PPos.SetSettings(settings);
+            await appService.UpdateOrCreateApp(existingP2PPos);
+            return new P2PPosSetupResult(defaultFormId, false, true);
+        }
+
+        var p2PPos = new AppData
+        {
+            StoreDataId = storeId,
+            Name = P2PDefaultPosName,
+            AppType = PointOfSaleAppType.AppType
+        };
+        p2PPos.SetSettings(CreateP2PPointOfSaleSettings(defaultFormId));
+        await appService.UpdateOrCreateApp(p2PPos);
+        return new P2PPosSetupResult(defaultFormId, true, false);
     }
-    
+
+    private static PointOfSaleSettings CreateP2PPointOfSaleSettings(string formId)
+    {
+        return new PointOfSaleSettings
+        {
+            Title = P2PDefaultPosName,
+            Currency = "BRL",
+            Template = AppService.SerializeTemplate(Array.Empty<AppItem>()),
+            DefaultView = BTCPayServer.Plugins.PointOfSale.PosViewType.Light,
+            ShowItems = false,
+            ShowCustomAmount = true,
+            ShowDiscount = false,
+            ShowSearch = false,
+            ShowCategories = false,
+            EnableTips = false,
+            FormId = formId
+        };
+    }
+
+    private async Task<string> EnsureDefaultP2PFormAsync(string storeId)
+    {
+        var forms = await formDataService.GetForms(storeId);
+        var existing = forms.FirstOrDefault(form => string.Equals(form.Name, P2PDefaultFormName, StringComparison.Ordinal));
+        if (existing is not null)
+        {
+            if (!FormDataHasP2PAddressField(existing))
+            {
+                existing.Config = CreateP2PAddressForm().ToString();
+                await formDataService.AddOrUpdateForm(existing);
+            }
+            return existing.Id;
+        }
+
+        var formData = new FormData
+        {
+            StoreId = storeId,
+            Name = P2PDefaultFormName,
+            Config = CreateP2PAddressForm().ToString()
+        };
+        await formDataService.AddOrUpdateForm(formData);
+        return formData.Id;
+    }
+
+    private static bool FormDataHasP2PAddressField(FormData? formData)
+    {
+        return TryParseForm(formData, out var form) &&
+               form.GetFieldByFullName(P2PDepixAddressFieldName) is { Required: true };
+    }
+
+    private static bool TryParseForm(FormData? formData, out Form form)
+    {
+        form = null!;
+        if (formData is null || string.IsNullOrWhiteSpace(formData.Config))
+            return false;
+
+        try
+        {
+            form = Form.Parse(formData.Config);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static Form CreateP2PAddressForm()
+    {
+        var form = new Form();
+        EnsureP2PAddressField(form);
+        return form;
+    }
+
+    private static void EnsureP2PAddressField(Form form)
+    {
+        if (form.GetFieldByFullName(P2PDepixAddressFieldName) is not null)
+            return;
+
+        form.Fields.Add(Field.Create(
+            "DePix address",
+            P2PDepixAddressFieldName,
+            null,
+            true,
+            "Buyer Liquid/DePix address that receives the purchased DePix."));
+    }
+
+    private sealed record P2PPosSetupResult(string FormId, bool PosAppCreated, bool PosAppUpdated);
+
     /// <summary>
     /// Displays Pix transactions for a store
     /// </summary>

--- a/BTCPayServer.Plugins.Depix/Controllers/PixController.cs
+++ b/BTCPayServer.Plugins.Depix/Controllers/PixController.cs
@@ -293,7 +293,15 @@ public class PixController(
         {
             if (!FormDataHasP2PAddressField(existing))
             {
-                existing.Config = CreateP2PAddressForm().ToString();
+                if (TryParseForm(existing, out var form))
+                {
+                    EnsureP2PAddressField(form);
+                    existing.Config = form.ToString();
+                }
+                else
+                {
+                    existing.Config = CreateP2PAddressForm().ToString();
+                }
                 await formDataService.AddOrUpdateForm(existing);
             }
             return existing.Id;

--- a/BTCPayServer.Plugins.Depix/Data/Models/ViewModels/PixStoreViewModel.cs
+++ b/BTCPayServer.Plugins.Depix/Data/Models/ViewModels/PixStoreViewModel.cs
@@ -49,12 +49,22 @@ public class PixStoreViewModel
     public bool PassFeeToCustomer { get; set; }
 
     /// <summary>
-    /// Optional address to split the payment to
+    /// Whether to sell DePix directly to a buyer-supplied DePix address
+    /// </summary>
+    public bool P2PMode { get; set; }
+
+    /// <summary>
+    /// Seller commission percentage for P2P sales
+    /// </summary>
+    public string? P2PCommissionPercent { get; set; }
+
+    /// <summary>
+    /// Optional address to split normal Pix payments to
     /// </summary>
     public string? DepixSplitAddress { get; set; }
 
     /// <summary>
-    /// Fee configuration for split payments
+    /// Fee configuration for normal Pix split payments
     /// </summary>
     public string? SplitFee { get; set; }
 

--- a/BTCPayServer.Plugins.Depix/Data/Models/ViewModels/PixTransactionsViewModel.cs
+++ b/BTCPayServer.Plugins.Depix/Data/Models/ViewModels/PixTransactionsViewModel.cs
@@ -2,15 +2,17 @@ using System;
 using System.Collections.Generic;
 using BTCPayServer.Plugins.Depix.Data.Enums;
 
+#nullable enable
+
 namespace BTCPayServer.Plugins.Depix.Data.Models.ViewModels
 {
     public class PixTransactionsViewModel
     {
         public List<PixTxResponse> Transactions { get; set; } = [];
-        public string StoreId { get; set; }
-        public string WalletId { get; set; }
+        public string StoreId { get; set; } = "";
+        public string WalletId { get; set; } = "";
         public PixConfigStatus ConfigStatus { get; set; } = new(false, false, false);
-        public PixTxQueryRequest QueryRequest { get; set; }
+        public PixTxQueryRequest? QueryRequest { get; set; }
     }
 
     public class PixTxResponse
@@ -18,9 +20,13 @@ namespace BTCPayServer.Plugins.Depix.Data.Models.ViewModels
         public string InvoiceId { get; set; } = "";
         public DateTimeOffset Created { get; set; }
         public string QrId { get; set; } = "";
-        public string DepixAddress { get; set; }   
+        public string DepixAddress { get; set; } = "";
+        public bool? P2PMode { get; set; }
+        public string? DepixSplitAddress { get; set; }
+        public string? P2PCommissionPercent { get; set; }
+        public string? SplitFee { get; set; }
         public int? ValueInCents { get; set; }
-        public string AmountBrl { get; set; }
+        public string AmountBrl { get; set; } = "";
         public string DepixStatusRaw { get; set; } = "pending";
         public DepixStatus? DepixStatus { get; set; } 
     }

--- a/BTCPayServer.Plugins.Depix/DePixPlugin.cs
+++ b/BTCPayServer.Plugins.Depix/DePixPlugin.cs
@@ -29,6 +29,7 @@ public class DePixPlugin : BaseBTCPayServerPlugin
         plugins.AddSingleton<DepixService>();
         plugins.AddSingleton<ISecretProtector, SecretProtector>();
         plugins.AddHttpClient();
+        plugins.AddHostedService<P2PInvoicePaymentMethodRestrictor>();
 
         plugins.AddSingleton(provider =>
             (IPaymentMethodHandler)ActivatorUtilities.CreateInstance(provider, typeof(PixPaymentMethodHandler)));

--- a/BTCPayServer.Plugins.Depix/PaymentHandlers/PixPaymentMethodConfig.cs
+++ b/BTCPayServer.Plugins.Depix/PaymentHandlers/PixPaymentMethodConfig.cs
@@ -29,12 +29,22 @@ public class PixPaymentMethodConfig
     public bool PassFeeToCustomer { get; set; }
 
     /// <summary>
-    /// Optional address to split the payment to
+    /// Whether Pix deposits should sell DePix directly to a buyer-supplied DePix address
+    /// </summary>
+    public bool P2PMode { get; set; }
+
+    /// <summary>
+    /// Seller commission percentage for P2P sales
+    /// </summary>
+    public string? P2PCommissionPercent { get; set; }
+
+    /// <summary>
+    /// Optional address to split normal Pix payments to
     /// </summary>
     public string? DepixSplitAddress { get; set; }
 
     /// <summary>
-    /// Fee configuration for split payments
+    /// Fee configuration for normal Pix split payments
     /// </summary>
     public string? SplitFee { get; set; }
 }

--- a/BTCPayServer.Plugins.Depix/PaymentHandlers/PixPaymentMethodHandler.cs
+++ b/BTCPayServer.Plugins.Depix/PaymentHandlers/PixPaymentMethodHandler.cs
@@ -7,6 +7,7 @@ using BTCPayServer.Data;
 using BTCPayServer.Payments;
 using BTCPayServer.Payments.Bitcoin;
 using BTCPayServer.Plugins.Altcoins;
+using BTCPayServer.Plugins.Depix.Errors;
 using BTCPayServer.Plugins.Depix.Services;
 using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json;
@@ -81,21 +82,30 @@ public class PixPaymentMethodHandler(
 
         string? p2PDestinationAddress = null;
         var p2PMode = pixCfg.P2PMode && TryGetP2PDestinationAddress(context, out p2PDestinationAddress);
-        var address = p2PMode
-            ? p2PDestinationAddress!
-            : await depixService.GenerateFreshDePixAddress(store.Id);
+        string address;
 
         string? depixSplitAddress = null;
         string? p2PCommissionPercent = null;
-        if (p2PMode)
+        try
         {
-            if (string.IsNullOrWhiteSpace(pixCfg.P2PCommissionPercent) ||
-                !DepixService.TryNormalizeSplitFee(pixCfg.P2PCommissionPercent, out p2PCommissionPercent))
-            {
-                throw new PaymentMethodUnavailableException("P2P mode requires a seller commission percentage");
-            }
+            address = p2PMode
+                ? p2PDestinationAddress!
+                : await depixService.GenerateFreshDePixAddress(store.Id);
 
-            depixSplitAddress = await depixService.GenerateFreshDePixAddress(store.Id);
+            if (p2PMode)
+            {
+                if (string.IsNullOrWhiteSpace(pixCfg.P2PCommissionPercent) ||
+                    !DepixService.TryNormalizeSplitFee(pixCfg.P2PCommissionPercent, out p2PCommissionPercent))
+                {
+                    throw new PaymentMethodUnavailableException("P2P mode requires a seller commission percentage");
+                }
+
+                depixSplitAddress = await depixService.GenerateFreshDePixAddress(store.Id);
+            }
+        }
+        catch (Exception ex) when (ex is PixPluginException or PixPaymentException)
+        {
+            throw new PaymentMethodUnavailableException(ex.Message);
         }
 
         var deposit = await depixService.RequestDepositAsync(

--- a/BTCPayServer.Plugins.Depix/PaymentHandlers/PixPaymentMethodHandler.cs
+++ b/BTCPayServer.Plugins.Depix/PaymentHandlers/PixPaymentMethodHandler.cs
@@ -144,11 +144,11 @@ public class PixPaymentMethodHandler(
             return false;
 
         if (token.Type != JTokenType.String)
-            throw new PaymentMethodUnavailableException("P2P mode requires invoice metadata depixAddress");
+            throw new PaymentMethodUnavailableException("P2P mode requires a DePix address");
 
         address = token.Value<string>()?.Trim();
         if (string.IsNullOrWhiteSpace(address))
-            throw new PaymentMethodUnavailableException("P2P mode requires invoice metadata depixAddress");
+            throw new PaymentMethodUnavailableException("P2P mode requires a DePix address");
 
         return true;
     }

--- a/BTCPayServer.Plugins.Depix/PaymentHandlers/PixPaymentMethodHandler.cs
+++ b/BTCPayServer.Plugins.Depix/PaymentHandlers/PixPaymentMethodHandler.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Data;
@@ -7,6 +8,8 @@ using BTCPayServer.Payments;
 using BTCPayServer.Payments.Bitcoin;
 using BTCPayServer.Plugins.Altcoins;
 using BTCPayServer.Plugins.Depix.Services;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using JsonSerializer = Newtonsoft.Json.JsonSerializer;
 
@@ -18,9 +21,12 @@ namespace BTCPayServer.Plugins.Depix.PaymentHandlers;
 public class PixPaymentMethodHandler(
     BTCPayNetworkProvider networkProvider,
     DepixService depixService,
+    IHttpContextAccessor httpContextAccessor,
     ISecretProtector secretProtector)
     : IPaymentMethodHandler, IHasNetwork
 {
+    private const string P2PDepixAddressMetadataKey = "depixAddress";
+
     /// <summary>
     /// The payment method ID for Pix
     /// </summary>
@@ -73,16 +79,98 @@ public class PixPaymentMethodHandler(
 
         using var client = depixService.CreateDepixClient(apiKey);
 
-        var address = await depixService.GenerateFreshDePixAddress(store.Id);
+        string? p2PDestinationAddress = null;
+        var p2PMode = pixCfg.P2PMode && TryGetP2PDestinationAddress(context, out p2PDestinationAddress);
+        var address = p2PMode
+            ? p2PDestinationAddress!
+            : await depixService.GenerateFreshDePixAddress(store.Id);
+
+        string? depixSplitAddress = null;
+        string? p2PCommissionPercent = null;
+        if (p2PMode)
+        {
+            if (string.IsNullOrWhiteSpace(pixCfg.P2PCommissionPercent) ||
+                !DepixService.TryNormalizeSplitFee(pixCfg.P2PCommissionPercent, out p2PCommissionPercent))
+            {
+                throw new PaymentMethodUnavailableException("P2P mode requires a seller commission percentage");
+            }
+
+            depixSplitAddress = await depixService.GenerateFreshDePixAddress(store.Id);
+        }
+
         var deposit = await depixService.RequestDepositAsync(
             client, 
             amountInCents, 
             address, 
             pixCfg,
             effectiveConfig.UseWhitelist,
-            CancellationToken.None);
+            CancellationToken.None,
+            depixSplitAddress,
+            p2PCommissionPercent);
 
-        depixService.ApplyPromptDetails(context, deposit, address, amountInCents);
+        depixService.ApplyPromptDetails(context, deposit, address, amountInCents, p2PMode, depixSplitAddress, p2PCommissionPercent);
+    }
+
+    private bool TryGetP2PDestinationAddress(PaymentMethodContext context, out string? address)
+    {
+        var metadata = context.InvoiceEntity.Metadata?.AdditionalData;
+        return TryGetP2PDestinationAddress(
+            metadata,
+            metadata?.ContainsKey(P2PDepixAddressMetadataKey) is true ? null : GetCurrentFormResponse(),
+            out address);
+    }
+
+    private static bool TryGetP2PDestinationAddress(
+        IDictionary<string, JToken>? metadata,
+        string? formResponse,
+        out string? address)
+    {
+        address = null;
+        var token = metadata is not null && metadata.TryGetValue(P2PDepixAddressMetadataKey, out var value)
+            ? value
+            : TryGetP2PDestinationAddressFromFormResponse(formResponse);
+
+        if (token is null)
+            return false;
+
+        if (token.Type != JTokenType.String)
+            throw new PaymentMethodUnavailableException("P2P mode requires invoice metadata depixAddress");
+
+        address = token.Value<string>()?.Trim();
+        if (string.IsNullOrWhiteSpace(address))
+            throw new PaymentMethodUnavailableException("P2P mode requires invoice metadata depixAddress");
+
+        return true;
+    }
+
+    private string? GetCurrentFormResponse()
+    {
+        var request = httpContextAccessor.HttpContext?.Request;
+        if (request is null)
+            return null;
+
+        if (request.HasFormContentType && request.Form.TryGetValue("formResponse", out var formResponse))
+            return formResponse.ToString();
+
+        return request.Query.TryGetValue("formResponse", out var queryFormResponse)
+            ? queryFormResponse.ToString()
+            : null;
+    }
+
+    private static JToken? TryGetP2PDestinationAddressFromFormResponse(string? formResponse)
+    {
+        if (string.IsNullOrWhiteSpace(formResponse))
+            return null;
+
+        try
+        {
+            var values = JObject.Parse(formResponse);
+            return values.TryGetValue(P2PDepixAddressMetadataKey, out var token) ? token : null;
+        }
+        catch (JsonReaderException)
+        {
+            return null;
+        }
     }
 
     /// <summary>
@@ -191,6 +279,24 @@ public class DePixPaymentMethodDetails
     /// The DePix address
     /// </summary>
     public string? DepixAddress { get; set; }
+    /// <summary>
+    /// Whether this Pix deposit was created in P2P mode
+    /// </summary>
+    [JsonProperty("p2pMode")]
+    public bool? P2PMode { get; set; }
+    /// <summary>
+    /// The DePix split address used for seller commission
+    /// </summary>
+    public string? DepixSplitAddress { get; set; }
+    /// <summary>
+    /// The seller commission percentage used for P2P sales
+    /// </summary>
+    [JsonProperty("p2pCommissionPercent")]
+    public string? P2PCommissionPercent { get; set; }
+    /// <summary>
+    /// Legacy split percentage field used by older P2P prompt details
+    /// </summary>
+    public string? SplitFee { get; set; }
     /// <summary>
     /// The status of the payment
     /// </summary>

--- a/BTCPayServer.Plugins.Depix/Services/DepixService.cs
+++ b/BTCPayServer.Plugins.Depix/Services/DepixService.cs
@@ -1165,7 +1165,7 @@ public sealed class P2PInvoicePaymentMethodRestrictor(
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        subscription = eventAggregator.Subscribe<InvoiceEvent>(HandleInvoiceEvent);
+        subscription = eventAggregator.SubscribeAsync<InvoiceEvent>(HandleInvoiceEvent);
         return Task.CompletedTask;
     }
 
@@ -1190,41 +1190,50 @@ public sealed class P2PInvoicePaymentMethodRestrictor(
         return true;
     }
 
-    private void HandleInvoiceEvent(InvoiceEvent invoiceEvent)
+    private async Task HandleInvoiceEvent(InvoiceEvent invoiceEvent)
     {
         if (invoiceEvent.Name != InvoiceEvent.Created)
             return;
 
-        RestrictInvoiceToPixIfP2PAsync(invoiceEvent.Invoice).GetAwaiter().GetResult();
+        await RestrictInvoiceToPixIfP2PAsync(invoiceEvent.Invoice);
     }
 
     private async Task RestrictInvoiceToPixIfP2PAsync(InvoiceEntity invoice)
     {
-        await using var dbContext = dbContextFactory.CreateContext();
-        var invoiceData = await dbContext.Invoices
-            .AsNoTracking()
-            .FirstOrDefaultAsync(data => data.Id == invoice.Id);
-        if (invoiceData is null)
-            return;
+        await using var strategyContext = dbContextFactory.CreateContext();
+        await strategyContext.Database.CreateExecutionStrategy().ExecuteAsync(async () =>
+        {
+            await using var dbContext = dbContextFactory.CreateContext();
+            await using var transaction = await dbContext.Database.BeginTransactionAsync();
+            var invoiceData = await dbContext.Invoices
+                .FromSqlInterpolated($"""
+                                      SELECT *, xmin
+                                      FROM "Invoices"
+                                      WHERE "Id" = {invoice.Id}
+                                      FOR UPDATE
+                                      """)
+                .SingleOrDefaultAsync();
+            if (invoiceData is null)
+                return;
 
-        var storedInvoice = invoiceData.GetBlob();
-        if (!TryRestrictInvoiceToPixIfP2P(storedInvoice))
-            return;
+            var storedInvoice = invoiceData.GetBlob();
+            if (!TryRestrictInvoiceToPixIfP2P(storedInvoice))
+                return;
 
-        invoiceData.SetBlob(storedInvoice);
+            invoiceData.SetBlob(storedInvoice);
 
-        await using var transaction = await dbContext.Database.BeginTransactionAsync();
-        await dbContext.Database.ExecuteSqlInterpolatedAsync($"""
-            UPDATE "Invoices"
-            SET "Blob2" = CAST({invoiceData.Blob2} AS jsonb)
-            WHERE "Id" = {invoice.Id}
-            """);
-        await dbContext.Database.ExecuteSqlInterpolatedAsync($"""
-            DELETE FROM "AddressInvoices"
-            WHERE "InvoiceDataId" = {invoice.Id}
-              AND "PaymentMethodId" <> {DePixPlugin.PixPmid.ToString()}
-            """);
-        await transaction.CommitAsync();
+            await dbContext.Database.ExecuteSqlInterpolatedAsync($"""
+                UPDATE "Invoices"
+                SET "Blob2" = CAST({invoiceData.Blob2} AS jsonb)
+                WHERE "Id" = {invoice.Id}
+                """);
+            await dbContext.Database.ExecuteSqlInterpolatedAsync($"""
+                DELETE FROM "AddressInvoices"
+                WHERE "InvoiceDataId" = {invoice.Id}
+                  AND "PaymentMethodId" <> {DePixPlugin.PixPmid.ToString()}
+                """);
+            await transaction.CommitAsync();
+        });
     }
 
     private static bool IsP2PPixPrompt(PaymentPrompt pixPrompt)

--- a/BTCPayServer.Plugins.Depix/Services/DepixService.cs
+++ b/BTCPayServer.Plugins.Depix/Services/DepixService.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -29,6 +30,7 @@ using BTCPayServer;
 using Dapper;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using NBXplorer;
@@ -274,7 +276,15 @@ public class DepixService(
     /// <param name="ct">Cancellation token</param>
     /// <returns>The deposit response containing QR code info</returns>
     /// <exception cref="PaymentMethodUnavailableException">Thrown if request fails</exception>
-    public async Task<DepixDepositResponse> RequestDepositAsync(HttpClient client, int amountInCents, string depixAddress, PixPaymentMethodConfig pixCfg, bool useWhitelist, CancellationToken ct)
+    public async Task<DepixDepositResponse> RequestDepositAsync(
+        HttpClient client,
+        int amountInCents,
+        string depixAddress,
+        PixPaymentMethodConfig pixCfg,
+        bool useWhitelist,
+        CancellationToken ct,
+        string? depixSplitAddressOverride = null,
+        string? splitFeeOverride = null)
     {
         var payload = new Dictionary<string, object>
         {
@@ -285,21 +295,41 @@ public class DepixService(
         if (useWhitelist)
             payload["whitelist"] = true;
 
-        var splitAddressTrimmed = pixCfg.DepixSplitAddress?.Trim();
-        if (!string.IsNullOrWhiteSpace(splitAddressTrimmed))
-            payload["depixSplitAddress"] = splitAddressTrimmed;
+        if (depixSplitAddressOverride is not null || splitFeeOverride is not null)
+        {
+            var splitAddressTrimmed = depixSplitAddressOverride?.Trim();
+            if (!string.IsNullOrWhiteSpace(splitAddressTrimmed))
+                payload["depixSplitAddress"] = splitAddressTrimmed;
 
-        var splitFeeTrimmed = pixCfg.SplitFee?.Trim();
-        if (!string.IsNullOrWhiteSpace(splitFeeTrimmed))
-            payload["splitFee"] = splitFeeTrimmed;
+            var splitFeeTrimmed = splitFeeOverride?.Trim();
+            if (!string.IsNullOrWhiteSpace(splitFeeTrimmed))
+                payload["splitFee"] = splitFeeTrimmed;
+        }
+        else
+        {
+            var splitAddressTrimmed = pixCfg.DepixSplitAddress?.Trim();
+            var splitFeeTrimmed = pixCfg.SplitFee?.Trim();
+            if (!string.IsNullOrWhiteSpace(splitAddressTrimmed) && !string.IsNullOrWhiteSpace(splitFeeTrimmed))
+            {
+                payload["depixSplitAddress"] = splitAddressTrimmed;
+                payload["splitFee"] = splitFeeTrimmed;
+            }
+        }
 
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
         var resp = await client.PostAsync("deposit", content, ct);
-        if (!resp.IsSuccessStatusCode)
-            throw new PaymentMethodUnavailableException("Failed to generate Pix QR Code");
-        
-
         var body = await resp.Content.ReadAsStringAsync(ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var response = string.IsNullOrWhiteSpace(body)
+                ? resp.ReasonPhrase
+                : body.Length > 500
+                    ? body[..500]
+                    : body;
+            throw new PaymentMethodUnavailableException(
+                $"Failed to generate Pix QR Code ({(int)resp.StatusCode} {response})");
+        }
+
         using var doc = JsonDocument.Parse(body);
         var root = doc.RootElement.GetProperty("response");
 
@@ -324,7 +354,14 @@ public class DepixService(
     /// <param name="depositResponse">The deposit response from DePix</param>
     /// <param name="depixAddress">The DePix address</param>
     /// <param name="amountInCents">The QR amount in cents</param>
-    public void ApplyPromptDetails(PaymentMethodContext context, DepixDepositResponse depositResponse, string depixAddress, int amountInCents)
+    public void ApplyPromptDetails(
+        PaymentMethodContext context,
+        DepixDepositResponse depositResponse,
+        string depixAddress,
+        int amountInCents,
+        bool p2PMode = false,
+        string? depixSplitAddress = null,
+        string? p2PCommissionPercent = null)
     {
         context.Prompt.Destination = depositResponse.QrImageUrl;
 
@@ -337,6 +374,20 @@ public class DepixService(
         details.QrImageUrl = depositResponse.QrImageUrl;
         details.CopyPaste = depositResponse.QrCopyPaste;
         details.DepixAddress = depixAddress;
+        if (p2PMode)
+        {
+            details.P2PMode = true;
+            details.DepixSplitAddress = depixSplitAddress;
+            details.P2PCommissionPercent = p2PCommissionPercent;
+            details.SplitFee = null;
+        }
+        else
+        {
+            details.P2PMode = null;
+            details.DepixSplitAddress = null;
+            details.P2PCommissionPercent = null;
+            details.SplitFee = null;
+        }
         if (amountInCents > 0)
             details.ValueInCents = amountInCents;
 
@@ -387,6 +438,12 @@ public class DepixService(
                      "Created"::timestamptz AS "Created",
                      ("Blob2"->'prompts'->'PIX'->'details'->>'qrId')          AS "QrId",
                      ("Blob2"->'prompts'->'PIX'->'details'->>'depixAddress')  AS "DepixAddress",
+                     NULLIF(("Blob2"->'prompts'->'PIX'->'details'->>'p2pMode'), '')::bool AS "P2PMode",
+                     ("Blob2"->'prompts'->'PIX'->'details'->>'depixSplitAddress') AS "DepixSplitAddress",
+                     COALESCE(
+                         ("Blob2"->'prompts'->'PIX'->'details'->>'p2pCommissionPercent'),
+                         ("Blob2"->'prompts'->'PIX'->'details'->>'splitFee')
+                     ) AS "P2PCommissionPercent",
                      NULLIF(("Blob2"->'prompts'->'PIX'->'details'->>'valueInCents'), '')::int AS "ValueInCents",
                      COALESCE(("Blob2"->'prompts'->'PIX'->'details'->>'status'), 'pending')   AS "DepixStatusRaw"
                    FROM "Invoices"
@@ -777,8 +834,8 @@ public class DepixService(
             PayerEuid = body.PayerEuid ?? existing?.PayerEuid,
             PayerTaxNumber = body.PayerTaxNumber ?? existing?.PayerTaxNumber,
             CustomerMessage = body.CustomerMessage ?? existing?.CustomerMessage
-        };
-    }
+    };
+}
 
     private static string GetPaymentId(string invoiceId, string qrId)
     {
@@ -931,6 +988,39 @@ public class DepixService(
         => !string.IsNullOrEmpty(encryptedApiKey) && !string.IsNullOrEmpty(webhookSecretHashHex);
 
     /// <summary>
+    /// Normalizes a split percentage to the DePix API format.
+    /// </summary>
+    /// <param name="raw">Raw percentage, with or without a percent suffix</param>
+    /// <param name="normalized">Normalized percentage with a percent suffix</param>
+    /// <returns>True if valid; otherwise false</returns>
+    public static bool TryNormalizeSplitFee(string raw, out string normalized)
+    {
+        normalized = "";
+        var trimmed = raw.Trim();
+        if (trimmed.EndsWith("%", StringComparison.Ordinal))
+            trimmed = trimmed[..^1].Trim();
+
+        if (string.IsNullOrEmpty(trimmed) || trimmed.Count(c => c == ',') > 1)
+            return false;
+
+        if (trimmed.Contains('.', StringComparison.Ordinal) && trimmed.Contains(',', StringComparison.Ordinal))
+            return false;
+
+        if (trimmed.Contains(',', StringComparison.Ordinal))
+            trimmed = trimmed.Replace(',', '.');
+
+        if (!decimal.TryParse(trimmed, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var value))
+            return false;
+        if (value <= 0m || value >= 100m)
+            return false;
+        var scale = (decimal.GetBits(value)[3] >> 16) & 0xFF;
+        if (scale > 2)
+            return false;
+        normalized = value.ToString("0.##", CultureInfo.InvariantCulture) + "%";
+        return true;
+    }
+
+    /// <summary>
     /// Gets the effective configuration (merging store and server configs)
     /// </summary>
     /// <param name="storeCfg">The store configuration</param>
@@ -1063,5 +1153,83 @@ public class DepixService(
         return chainName == ChainName.Mainnet
             ? "https://liquid.network/tx/{0}"
             : "https://liquid.network/testnet/tx/{0}";
+    }
+}
+
+public sealed class P2PInvoicePaymentMethodRestrictor(
+    EventAggregator eventAggregator,
+    ApplicationDbContextFactory dbContextFactory)
+    : IHostedService
+{
+    private IEventAggregatorSubscription? subscription;
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        subscription = eventAggregator.Subscribe<InvoiceEvent>(HandleInvoiceEvent);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        subscription?.Dispose();
+        subscription = null;
+        return Task.CompletedTask;
+    }
+
+    public static bool TryRestrictInvoiceToPixIfP2P(InvoiceEntity invoice)
+    {
+        var prompts = invoice.GetPaymentPrompts().ToList();
+        var pixPrompt = prompts.FirstOrDefault(prompt => prompt.PaymentMethodId == DePixPlugin.PixPmid);
+        if (pixPrompt is null || !IsP2PPixPrompt(pixPrompt) ||
+            prompts.All(prompt => prompt.PaymentMethodId == DePixPlugin.PixPmid))
+        {
+            return false;
+        }
+
+        invoice.SetPaymentPrompts(new PaymentPromptDictionary([pixPrompt]));
+        return true;
+    }
+
+    private void HandleInvoiceEvent(InvoiceEvent invoiceEvent)
+    {
+        if (invoiceEvent.Name != InvoiceEvent.Created)
+            return;
+
+        RestrictInvoiceToPixIfP2PAsync(invoiceEvent.Invoice).GetAwaiter().GetResult();
+    }
+
+    private async Task RestrictInvoiceToPixIfP2PAsync(InvoiceEntity invoice)
+    {
+        await using var dbContext = dbContextFactory.CreateContext();
+        var invoiceData = await dbContext.Invoices
+            .AsNoTracking()
+            .FirstOrDefaultAsync(data => data.Id == invoice.Id);
+        if (invoiceData is null)
+            return;
+
+        var storedInvoice = invoiceData.GetBlob();
+        if (!TryRestrictInvoiceToPixIfP2P(storedInvoice))
+            return;
+
+        invoiceData.SetBlob(storedInvoice);
+
+        await using var transaction = await dbContext.Database.BeginTransactionAsync();
+        await dbContext.Database.ExecuteSqlInterpolatedAsync($"""
+            UPDATE "Invoices"
+            SET "Blob2" = CAST({invoiceData.Blob2} AS jsonb)
+            WHERE "Id" = {invoice.Id}
+            """);
+        await dbContext.Database.ExecuteSqlInterpolatedAsync($"""
+            DELETE FROM "AddressInvoices"
+            WHERE "InvoiceDataId" = {invoice.Id}
+              AND "PaymentMethodId" <> {DePixPlugin.PixPmid.ToString()}
+            """);
+        await transaction.CommitAsync();
+    }
+
+    private static bool IsP2PPixPrompt(PaymentPrompt pixPrompt)
+    {
+        var token = pixPrompt.Details?["p2pMode"] ?? pixPrompt.Details?["P2PMode"];
+        return token is { Type: JTokenType.Boolean } && token.Value<bool>();
     }
 }

--- a/BTCPayServer.Plugins.Depix/Views/Pix/PixSettings.cshtml
+++ b/BTCPayServer.Plugins.Depix/Views/Pix/PixSettings.cshtml
@@ -19,6 +19,7 @@
     );
 
     var hasAnyEffectiveConfig = Model.IsStoreCfgValid || Model.EffectiveUsesServerConfig;
+    var webhookOpen = !string.IsNullOrEmpty(Model.OneShotSecretToDisplay);
 }
 
 <form method="post" asp-action="PixSettings" asp-route-walletId="@(walletId?.ToString())">
@@ -30,96 +31,115 @@
     <partial name="_StatusMessage" />
 
     <div class="row">
-        <div class="col-md-8">
+        <div class="col-lg-7 col-md-9">
 
             @if (Model.EffectiveUsesServerConfig && !Model.IsStoreCfgValid)
             {
-                <div class="alert alert-info my-4">
-                    A <strong>server-level DePix Api Key configuration</strong> is available.
-                    If you do not configure for this store, the server configuration will be used.
+                <div class="alert alert-info mt-4 mb-0">
+                    Server-level DePix configuration is available for this store.
                 </div>
             }
 
-            <div class="form-group my-4">
-                <label asp-for="ApiKey">DePix API Key</label>
-                <input asp-for="ApiKey" type="text" class="form-control" />
-                <span asp-validation-for="ApiKey" class="text-danger"></span>
+            <section class="py-4 border-bottom">
+                <h3 class="h5 mb-3">Connection</h3>
+                <div class="form-group mb-0">
+                    <label asp-for="ApiKey">DePix API Key</label>
+                    <input asp-for="ApiKey" type="text" class="form-control" />
+                    <span asp-validation-for="ApiKey" class="text-danger"></span>
+                    <small class="form-text text-muted">
+                        Leave blank to use server configuration when available. Request a key at
+                        <a href="https://www.depix.info/#partners" target="_blank" rel="noopener noreferrer">depix.info/#partners</a>.
+                    </small>
+                </div>
 
-                <small class="form-text text-muted">
-                    Don’t have an API key? Request one at
-                    <a href="https://www.depix.info/#partners" target="_blank" rel="noopener noreferrer">
-                        depix.info/#partners
-                    </a>.
-                    <br />
-                    If this server is configured by the server admin, you may not need to set a store API key.
-                </small>
-            </div>
-
-            @if (hasAnyEffectiveConfig)
-            {
-                <div class="my-4">
-                    <label class="d-flex align-items-center">
+                @if (hasAnyEffectiveConfig)
+                {
+                    <label class="d-flex align-items-center mt-3 mb-0">
                         <input asp-for="IsEnabled" type="checkbox" class="btcpay-toggle me-2" />
                         <span>Enable Pix</span>
                     </label>
-                </div>
-                <div class="form-group my-4">
-                    <label asp-for="DepixSplitAddress">DePix Split Address (Optional)</label>
-                    <input asp-for="DepixSplitAddress" type="text" class="form-control" />
-                    <span asp-validation-for="DepixSplitAddress" class="text-danger"></span>
-                    <small class="form-text text-muted">
-                        Wallet that receives the split portion defined by Split Fee.
-                    </small>
-                </div>
+                }
+            </section>
 
-                <div class="form-group my-4">
-                    <label asp-for="SplitFee">Split Fee (Optional)</label>
-                    <input asp-for="SplitFee" type="number" class="form-control" step="0.01" min="0" max="100" />
-                    <span asp-validation-for="SplitFee" class="text-danger"></span>
-                    <small class="form-text text-muted">
-                        Percentage of the Pix amount sent to the Split Address.
+            @if (hasAnyEffectiveConfig)
+            {
+                <details class="py-4 border-bottom">
+                    <summary class="h5">Split</summary>
+                    <div class="form-group mt-3 mb-0">
+                        <label asp-for="DepixSplitAddress">Split address</label>
+                        <input asp-for="DepixSplitAddress" type="text" class="form-control" />
+                        <span asp-validation-for="DepixSplitAddress" class="text-danger"></span>
+                        <small class="form-text text-muted">
+                            DePix address that receives the split portion of regular Pix payments.
+                        </small>
+                    </div>
+
+                    <div class="form-group mt-3 mb-0">
+                        <label asp-for="SplitFee">Split fee (%)</label>
+                        <input asp-for="SplitFee" type="text" inputmode="decimal" class="form-control" />
+                        <span asp-validation-for="SplitFee" class="text-danger"></span>
+                        <small class="form-text text-muted">
+                            Percentage of each regular Pix payment sent to the split address. Both split fields are required together.
+                        </small>
+                    </div>
+                </details>
+
+                <details class="py-4 border-bottom">
+                    <summary class="h5">P2P mode</summary>
+                    <label class="d-flex align-items-center mt-3">
+                        <input asp-for="P2PMode" type="checkbox" class="btcpay-toggle me-2" />
+                        <span>Enable P2P mode</span>
+                    </label>
+                    <small class="text-muted d-block">
+                        Creates a separate P2P POS checkout where the buyer enters the DePix address.
                     </small>
-                </div>
+
+                    <div class="form-group mt-3 mb-0">
+                        <label asp-for="P2PCommissionPercent">P2P commission (%)</label>
+                        <input asp-for="P2PCommissionPercent" type="text" inputmode="decimal" class="form-control" />
+                        <span asp-validation-for="P2PCommissionPercent" class="text-danger"></span>
+                        <small class="form-text text-muted">
+                            Seller commission kept from P2P sales.
+                        </small>
+                    </div>
+                </details>
 
                 @if (Model.IsStoreCfgValid)
                 {
-                    <div class="my-3">
-                        <label class="d-flex align-items-center">
+                    <details class="py-4 border-bottom">
+                        <summary class="h5">Payment options</summary>
+                        <label class="d-flex align-items-center mt-3">
                             <input asp-for="PassFeeToCustomer" type="checkbox" class="btcpay-toggle me-2" />
                             <span>Pass DePix fee to customer</span>
                         </label>
                         <small class="text-muted d-block">
-                            When enabled, R$ 1.00 is added to the QR amount (customer pays the DePix fee).
+                            Adds R$ 1.00 to the QR amount.
                         </small>
-                    </div>
-                    
-                    <div class="my-3">
-                        <label class="d-flex align-items-center">
+
+                        <label class="d-flex align-items-center mt-3">
                             <input asp-for="UseWhitelist" type="checkbox" class="btcpay-toggle me-2" />
                             <span>Whitelist mode</span>
                         </label>
                         <small class="text-muted d-block">
-                            When enabled, the deposit request will include <code>whitelist</code> = <code>true</code>. Only enable this if you know what you are doing.
+                            Sends <code>whitelist</code> = <code>true</code> in the DePix deposit request.
                         </small>
-                    </div>
-                    
-                    <div class="card my-4">
-                        <div class="card-header d-flex align-items-center justify-content-between">
-                            <span>Webhook</span>
-                        </div>
-                        <div class="card-body">
+                    </details>
 
-                            <p class="text-muted mb-3">
-                                Register this webhook on Telegram with Eulen:
-                                <code>/registerwebhook deposit &lt;url&gt; &lt;secret&gt;</code>
-                            </p>
+                    <details class="py-4" open="@webhookOpen">
+                        <summary class="h5">Webhook</summary>
+                        <div class="mt-3">
+                            @if (!string.IsNullOrEmpty(Model.OneShotSecretToDisplay))
+                            {
+                                <div class="alert alert-warning mb-3">
+                                    <strong>Copy this secret now.</strong> It will not be shown again.
+                                </div>
+                            }
 
                             <div class="form-group mb-3">
                                 <label asp-for="WebhookUrl">Webhook URL</label>
                                 <div class="input-group">
                                     <input asp-for="WebhookUrl" class="form-control" id="WebhookUrl" readonly />
-                                    <button type="button" class="btn btn-outline-secondary"
-                                            data-clipboard-target="#WebhookUrl">
+                                    <button type="button" class="btn btn-outline-secondary" data-clipboard-target="#WebhookUrl">
                                         Copy
                                     </button>
                                 </div>
@@ -127,33 +147,22 @@
 
                             @if (!string.IsNullOrEmpty(Model.OneShotSecretToDisplay))
                             {
-                                <div class="alert alert-warning">
-                                    <strong>Copy this secret now.</strong> It will not be shown again.
-                                </div>
-
                                 <div class="form-group mb-3">
-                                    <label>Webhook Secret (one-time view)</label>
+                                    <label>Webhook Secret</label>
                                     <div class="input-group">
                                         <input value="@Model.OneShotSecretToDisplay" class="form-control" id="OneShotSecret" readonly />
-                                        <button type="button" class="btn btn-outline-secondary"
-                                                data-clipboard-target="#OneShotSecret">
+                                        <button type="button" class="btn btn-outline-secondary" data-clipboard-target="#OneShotSecret">
                                             Copy
                                         </button>
                                     </div>
-                                    <small class="form-text text-muted">
-                                        32 bytes hex (64 chars).
-                                    </small>
                                 </div>
 
-                                <div class="form-group mb-3">
+                                <div class="form-group mb-0">
                                     <label>Telegram command</label>
                                     <div class="input-group">
                                         <input value="/registerwebhook deposit @Model.WebhookUrl @Model.OneShotSecretToDisplay"
                                                class="form-control" id="TelegramRegisterCommand" readonly />
-                                        <button type="button" class="btn btn-outline-secondary"
-                                                data-clipboard-target="#TelegramRegisterCommand">
-                                            Copy
-                                        </button>
+                                        <button type="button" class="btn btn-outline-secondary" data-clipboard-target="#TelegramRegisterCommand">Copy</button>
                                     </div>
                                 </div>
                             }
@@ -162,32 +171,17 @@
                                 <div class="form-group mb-3">
                                     <label>Webhook Secret</label>
                                     <input value="@Model.WebhookSecretDisplay" class="form-control" id="WebhookSecretDisplay" readonly />
-                                    <small class="form-text text-muted">
-                                        If empty, Save to generate. If you lost it, check “Regenerate secret” and Save to get a new one-time secret.
-                                    </small>
                                 </div>
 
-                                <div class="form-check mb-3">
+                                <div class="form-check mb-0">
                                     <input class="form-check-input" asp-for="RegenerateWebhookSecret" id="RegenerateWebhookSecret" type="checkbox" />
                                     <label class="form-check-label" for="RegenerateWebhookSecret">
                                         Regenerate secret on save
                                     </label>
                                 </div>
-
-                                <div class="form-group mb-3">
-                                    <label>Telegram command</label>
-                                    <div class="input-group">
-                                        <input value="/registerwebhook deposit @Model.WebhookUrl <SECRET_WILL_BE_GENERATED>"
-                                               class="form-control" id="TelegramRegisterCommand" readonly />
-                                        <button type="button" class="btn btn-outline-secondary"
-                                                data-clipboard-target="#TelegramRegisterCommand">
-                                            Copy
-                                        </button>
-                                    </div>
-                                </div>
                             }
                         </div>
-                    </div>
+                    </details>
                 }
             }
             else

--- a/BTCPayServer.Plugins.Depix/Views/Pix/PixTransactions.cshtml
+++ b/BTCPayServer.Plugins.Depix/Views/Pix/PixTransactions.cshtml
@@ -115,7 +115,7 @@ else if (!Model.ConfigStatus.PixEnabled)
         </div>
         <div class="col-md-4">
             <label class="form-label" text-translate="true">Search</label>
-            <input name="q" value="@query" class="form-control" placeholder="InvoiceId, QR ID, Depix Address..." />
+            <input name="q" value="@query" class="form-control" placeholder="InvoiceId, QR ID, DePix Address..." />
         </div>
         <div class="col-md-2">
             <label class="form-label" text-translate="true">From</label>
@@ -148,7 +148,9 @@ else if (!Model.ConfigStatus.PixEnabled)
             <th>QR ID</th>
             <th class="text-end">Amount</th>
             <th>Status</th>
-            <th>Depix Address</th>
+            <th>Mode</th>
+            <th>DePix Address</th>
+            <th>Commission</th>
         </tr>
         </thead>
         <tbody>
@@ -184,6 +186,17 @@ else if (!Model.ConfigStatus.PixEnabled)
                 <td><span class="badge @Badge(raw)">@raw</span></td>
 
                 <td>
+                    @if (d.P2PMode is true)
+                    {
+                        <span class="badge bg-info text-dark">P2P</span>
+                    }
+                    else
+                    {
+                        <span>-</span>
+                    }
+                </td>
+
+                <td>
                     @if (!string.IsNullOrEmpty(d.DepixAddress))
                     {
                         <span class="d-inline-block text-truncate clipboard-button"
@@ -195,6 +208,27 @@ else if (!Model.ConfigStatus.PixEnabled)
                         </span>
                     }
                     else { <span>-</span> }
+                </td>
+
+                <td>
+                    @if (d.P2PMode is true && !string.IsNullOrEmpty(d.P2PCommissionPercent))
+                    {
+                        <span>@d.P2PCommissionPercent</span>
+                        @if (!string.IsNullOrEmpty(d.DepixSplitAddress))
+                        {
+                            <span class="d-inline-block text-truncate clipboard-button ms-2"
+                                  data-clipboard="@d.DepixSplitAddress"
+                                  style="max-width:180px"
+                                  data-bs-toggle="tooltip" data-bs-placement="top"
+                                  title="@d.DepixSplitAddress">
+                                  @d.DepixSplitAddress
+                            </span>
+                        }
+                    }
+                    else
+                    {
+                        <span>-</span>
+                    }
                 </td>
             </tr>
         }

--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ Use this when:
    - **DePix Split Address**: wallet that receives the split portion
    - **Split Fee**: percentage of the Pix amount sent to the split address
    - Both fields are required together; leave both empty to disable split
+5. (Optional) Enable **P2P mode** to sell DePix through POS/API:
+   - P2P invoices must include metadata field **`depixAddress`** with the buyer's DePix address.
+   - **P2P commission** sets the seller commission percentage.
+   - The commission address is configured by the plugin P2P flow.
+   - A separate **DePix P2P** POS app and checkout form are created automatically.
 
 Example use cases for split payments:
 - **Merchant gateway**: you provide Pix via your Eulen API + BTCPay setup and charge a platform fee.
@@ -137,6 +142,7 @@ Notes:
 
 * **Invoices**: create an invoice as usual; customers will see **Pix** as a payment method.
 * **POS**: generate charges from your Point of Sale; Pix is available.
+* **P2P POS**: enable P2P mode in **Wallets → Pix → Settings** and set the seller commission in **Split Fee**. The plugin creates a separate **DePix P2P** POS app with the required `depixAddress` form field, while existing POS apps can keep using normal Pix.
 
 ![Pix Invoice](docs/img/pix-invoice.png)
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Use this when:
    - Both fields are required together; leave both empty to disable split
 5. (Optional) Enable **P2P mode** to sell DePix through POS/API:
    - P2P invoices must include metadata field **`depixAddress`** with the buyer's DePix address.
-   - **P2P commission** sets the seller commission percentage.
+   - **P2P commission (%)** sets the seller commission percentage.
    - The commission address is configured by the plugin P2P flow.
    - A separate **DePix P2P** POS app and checkout form are created automatically.
 
@@ -142,7 +142,7 @@ Notes:
 
 * **Invoices**: create an invoice as usual; customers will see **Pix** as a payment method.
 * **POS**: generate charges from your Point of Sale; Pix is available.
-* **P2P POS**: enable P2P mode in **Wallets → Pix → Settings** and set the seller commission in **Split Fee**. The plugin creates a separate **DePix P2P** POS app with the required `depixAddress` form field, while existing POS apps can keep using normal Pix.
+* **P2P POS**: enable P2P mode in **Wallets → Pix → Settings** and set the seller commission in **P2P commission (%)**. The plugin creates a separate **DePix P2P** POS app with the required `depixAddress` form field, while existing POS apps can keep using normal Pix.
 
 ![Pix Invoice](docs/img/pix-invoice.png)
 


### PR DESCRIPTION
## What changed

This adds a new DePix P2P mode for stores.

With P2P mode enabled, the store can create a dedicated DePix P2P POS checkout where the buyer enters their own DePix address. The store owner can also set a P2P commission percentage, so each sale sends the buyer their DePix amount while keeping the configured seller commission.

The Pix Settings page was also reorganized to make the setup clearer:

- `Connection`: API key and Pix enable switch
- `Split`: regular Pix split address and split fee
- `P2P mode`: P2P checkout and seller commission
- `Payment options`: fee passthrough and whitelist mode
- `Webhook`: webhook URL and secret setup

Resolves #31