### PR TITLE
Add DePix deposit compliance for payer CPF/CNPJ

### DIFF
--- a/BTCPayServer.Plugins.Depix.Tests/PixPaymentMethodHandlerTests.cs
+++ b/BTCPayServer.Plugins.Depix.Tests/PixPaymentMethodHandlerTests.cs
@@ -1,17 +1,11 @@
-using System;
-using System.Collections.Generic;
 using System.Net;
-using System.Net.Http;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Data;
 using BTCPayServer.Logging;
 using BTCPayServer.Payments;
 using BTCPayServer.Plugins.Depix.Data.Models;
-using BTCPayServer.Plugins.Depix.Errors;
 using BTCPayServer.Plugins.Depix.PaymentHandlers;
 using BTCPayServer.Plugins.Depix.Services;
 using BTCPayServer.Rating;
@@ -25,6 +19,7 @@ namespace BTCPayServer.Plugins.Depix.Tests;
 public class PixPaymentMethodHandlerTests
 {
     private static readonly PaymentMethodId PixPmid = new("PIX");
+    private const string TestEndUserTaxNumber = "12345678901";
 
     [Theory]
     [InlineData("0,5", "0.5%")]
@@ -216,11 +211,14 @@ public class PixPaymentMethodHandlerTests
                 SplitFee = "3%"
             },
             useWhitelist: true,
+            TestEndUserTaxNumber,
             CancellationToken.None);
 
         var payload = JObject.Parse(capture.Body!);
         Assert.Equal(10000, payload.Value<int>("amountInCents"));
         Assert.Equal("merchant-depix-address", payload.Value<string>("depixAddress"));
+        Assert.Equal("12345678901", payload.Value<string>("endUserTaxNumber"));
+        Assert.False(payload.ContainsKey("endUserFullName"));
         Assert.Equal("configured-split-address", payload.Value<string>("depixSplitAddress"));
         Assert.Equal("3%", payload.Value<string>("splitFee"));
         Assert.True(payload.Value<bool>("whitelist"));
@@ -243,6 +241,7 @@ public class PixPaymentMethodHandlerTests
                 P2PCommissionPercent = "5%"
             },
             useWhitelist: false,
+            TestEndUserTaxNumber,
             CancellationToken.None);
 
         var payload = JObject.Parse(capture.Body!);
@@ -268,6 +267,7 @@ public class PixPaymentMethodHandlerTests
                 SplitFee = "3%"
             },
             useWhitelist: false,
+            TestEndUserTaxNumber,
             CancellationToken.None,
             depixSplitAddressOverride: "fresh-store-commission-address",
             splitFeeOverride: "5%");
@@ -295,10 +295,69 @@ public class PixPaymentMethodHandlerTests
                 "buyer-depix-address",
                 new PixPaymentMethodConfig(),
                 useWhitelist: false,
+                TestEndUserTaxNumber,
                 CancellationToken.None));
 
         Assert.Contains("400", ex.Message);
         Assert.Contains("invalid depixSplitAddress", ex.Message);
+    }
+
+    [Fact]
+    public void PayerTaxNumberReadsInvoiceMetadata()
+    {
+        var method = typeof(PixPaymentMethodHandler).GetMethod(
+            "ResolvePayerTaxNumber",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        object?[] args =
+        [
+            new Dictionary<string, JToken>
+            {
+                ["endUserTaxNumber"] = " 12345678901 "
+            },
+            null
+        ];
+
+        var taxNumber = Assert.IsType<string>(method.Invoke(null, args));
+        Assert.Equal("12345678901", taxNumber);
+    }
+
+    [Fact]
+    public void PayerTaxNumberReadsPendingPosFormResponse()
+    {
+        var method = typeof(PixPaymentMethodHandler).GetMethod(
+            "ResolvePayerTaxNumber",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        object?[] args =
+        [
+            null,
+            """{"endUserTaxNumber":"12345678901"}"""
+        ];
+
+        var taxNumber = Assert.IsType<string>(method.Invoke(null, args));
+        Assert.Equal("12345678901", taxNumber);
+    }
+
+    [Fact]
+    public void PayerTaxNumberIsRequired()
+    {
+        var method = typeof(PixPaymentMethodHandler).GetMethod(
+            "ResolvePayerTaxNumber",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        object?[] args =
+        [
+            new Dictionary<string, JToken>
+            {
+                ["buyerName"] = "Alice Buyer"
+            },
+            null
+        ];
+
+        var ex = Assert.Throws<TargetInvocationException>(() => method.Invoke(null, args));
+        var unavailable = Assert.IsType<PaymentMethodUnavailableException>(ex.InnerException);
+        Assert.Contains("CPF/CNPJ", unavailable.Message);
     }
 
     [Fact]

--- a/BTCPayServer.Plugins.Depix.Tests/PixPaymentMethodHandlerTests.cs
+++ b/BTCPayServer.Plugins.Depix.Tests/PixPaymentMethodHandlerTests.cs
@@ -223,6 +223,28 @@ public class PixPaymentMethodHandlerTests
         Assert.True(payload.Value<bool>("whitelist"));
     }
 
+    [Theory]
+    [InlineData(" 012.345.678-90 ", "01234567890")]
+    [InlineData("12.345.678/0001-95", "12345678000195")]
+    public async Task RequestDepositRemovesTaxNumberFormattingBeforeSending(string input, string expected)
+    {
+        var capture = new CaptureDepositRequestHandler();
+        using var client = new HttpClient(capture) { BaseAddress = new Uri("https://example.invalid/api/") };
+        var service = new DepixService(null!, null!, null!, null!, null!, null!, null!, null!, null!);
+
+        await service.RequestDepositAsync(
+            client,
+            10000,
+            "merchant-depix-address",
+            new PixPaymentMethodConfig(),
+            useWhitelist: false,
+            input,
+            CancellationToken.None);
+
+        var payload = JObject.Parse(capture.Body!);
+        Assert.Equal(expected, payload.Value<string>("endUserTaxNumber"));
+    }
+
     [Fact]
     public async Task RequestDepositDoesNotSendConfiguredSplitFeeWithoutConfiguredSplitAddress()
     {

--- a/BTCPayServer.Plugins.Depix.Tests/PixPaymentMethodHandlerTests.cs
+++ b/BTCPayServer.Plugins.Depix.Tests/PixPaymentMethodHandlerTests.cs
@@ -19,7 +19,7 @@ namespace BTCPayServer.Plugins.Depix.Tests;
 public class PixPaymentMethodHandlerTests
 {
     private static readonly PaymentMethodId PixPmid = new("PIX");
-    private const string TestEndUserTaxNumber = "12345678901";
+    private const string TestEndUserTaxNumber = "01234567890";
 
     [Theory]
     [InlineData("0,5", "0.5%")]
@@ -217,7 +217,7 @@ public class PixPaymentMethodHandlerTests
         var payload = JObject.Parse(capture.Body!);
         Assert.Equal(10000, payload.Value<int>("amountInCents"));
         Assert.Equal("merchant-depix-address", payload.Value<string>("depixAddress"));
-        Assert.Equal("12345678901", payload.Value<string>("endUserTaxNumber"));
+        Assert.Equal(TestEndUserTaxNumber, payload.Value<string>("endUserTaxNumber"));
         Assert.False(payload.ContainsKey("endUserFullName"));
         Assert.Equal("configured-split-address", payload.Value<string>("depixSplitAddress"));
         Assert.Equal("3%", payload.Value<string>("splitFee"));
@@ -313,13 +313,13 @@ public class PixPaymentMethodHandlerTests
         [
             new Dictionary<string, JToken>
             {
-                ["endUserTaxNumber"] = " 12345678901 "
+                ["endUserTaxNumber"] = $" {TestEndUserTaxNumber} "
             },
             null
         ];
 
         var taxNumber = Assert.IsType<string>(method.Invoke(null, args));
-        Assert.Equal("12345678901", taxNumber);
+        Assert.Equal(TestEndUserTaxNumber, taxNumber);
     }
 
     [Fact]
@@ -332,11 +332,32 @@ public class PixPaymentMethodHandlerTests
         object?[] args =
         [
             null,
-            """{"endUserTaxNumber":"12345678901"}"""
+            $$"""{"endUserTaxNumber":"{{TestEndUserTaxNumber}}"}"""
         ];
 
         var taxNumber = Assert.IsType<string>(method.Invoke(null, args));
-        Assert.Equal("12345678901", taxNumber);
+        Assert.Equal(TestEndUserTaxNumber, taxNumber);
+    }
+
+    [Fact]
+    public void PayerTaxNumberRejectsNumericMetadata()
+    {
+        var method = typeof(PixPaymentMethodHandler).GetMethod(
+            "ResolvePayerTaxNumber",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        object?[] args =
+        [
+            new Dictionary<string, JToken>
+            {
+                ["endUserTaxNumber"] = new JValue(99999999999L)
+            },
+            null
+        ];
+
+        var ex = Assert.Throws<TargetInvocationException>(() => method.Invoke(null, args));
+        var unavailable = Assert.IsType<PaymentMethodUnavailableException>(ex.InnerException);
+        Assert.Contains("string", unavailable.Message);
     }
 
     [Fact]

--- a/BTCPayServer.Plugins.Depix.Tests/PixPaymentMethodHandlerTests.cs
+++ b/BTCPayServer.Plugins.Depix.Tests/PixPaymentMethodHandlerTests.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Data;
 using BTCPayServer.Logging;
@@ -332,7 +331,7 @@ public class PixPaymentMethodHandlerTests
         object?[] args =
         [
             null,
-            $$"""{"endUserTaxNumber":"{{TestEndUserTaxNumber}}"}"""
+            JObject.Parse($$"""{"endUserTaxNumber":"{{TestEndUserTaxNumber}}"}""")
         ];
 
         var taxNumber = Assert.IsType<string>(method.Invoke(null, args));
@@ -384,32 +383,21 @@ public class PixPaymentMethodHandlerTests
     [Fact]
     public void P2PDestinationAddressRejectsNonStringMetadataAsUnavailable()
     {
-        var handler = RuntimeHelpers.GetUninitializedObject(typeof(PixPaymentMethodHandler));
-        var method = typeof(PixPaymentMethodHandler).GetMethod("TryGetP2PDestinationAddress", BindingFlags.Instance | BindingFlags.NonPublic)!;
-        var invoice = new InvoiceEntity
-        {
-            Id = "invoice-p2p-non-string-metadata",
-            Currency = "BRL",
-            Price = 12.34m,
-            Status = InvoiceStatus.New,
-            Metadata = new InvoiceMetadata
-            {
-                AdditionalData = new Dictionary<string, JToken>
-                {
-                    ["depixAddress"] = new JValue(123)
-                }
-            }
-        };
-        var context = new PaymentMethodContext(
-            new BTCPayServer.Data.StoreData { Id = "store-p2p-non-string-metadata" },
-            new StoreBlob(),
-            new JObject(),
-            new TestPixHandler(),
-            invoice,
-            new InvoiceLogs());
+        var method = typeof(PixPaymentMethodHandler).GetMethod(
+            "TryGetP2PDestinationAddress",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
 
-        object?[] args = [context, null];
-        var ex = Assert.Throws<TargetInvocationException>(() => method.Invoke(handler, args));
+        object?[] args =
+        [
+            new Dictionary<string, JToken>
+            {
+                ["depixAddress"] = new JValue(123)
+            },
+            null,
+            null
+        ];
+
+        var ex = Assert.Throws<TargetInvocationException>(() => method.Invoke(null, args));
         var unavailable = Assert.IsType<PaymentMethodUnavailableException>(ex.InnerException);
         Assert.Equal("P2P mode requires a DePix address", unavailable.Message);
     }
@@ -424,7 +412,7 @@ public class PixPaymentMethodHandlerTests
         object?[] args =
         [
             null,
-            """{"depixAddress":" buyer-depix-address "}""",
+            JObject.Parse("""{"depixAddress":" buyer-depix-address "}"""),
             null
         ];
 
@@ -447,7 +435,7 @@ public class PixPaymentMethodHandlerTests
             {
                 ["depixAddress"] = "metadata-depix-address"
             },
-            """{"depixAddress":"form-depix-address"}""",
+            JObject.Parse("""{"depixAddress":"form-depix-address"}"""),
             null
         ];
 
@@ -467,7 +455,7 @@ public class PixPaymentMethodHandlerTests
         object?[] args =
         [
             null,
-            """{"depixAddress":123}""",
+            JObject.Parse("""{"depixAddress":123}"""),
             null
         ];
 

--- a/BTCPayServer.Plugins.Depix.Tests/PixSettingsTests.cs
+++ b/BTCPayServer.Plugins.Depix.Tests/PixSettingsTests.cs
@@ -1,5 +1,3 @@
-using System.Threading.Tasks;
-using System.Linq;
 using BTCPayServer.Abstractions.Form;
 using BTCPayServer.Abstractions.Models;
 using BTCPayServer.Data;
@@ -123,9 +121,7 @@ public class PixSettingsTests : PlaywrightBaseTest
         var formData = await formDataService.GetForm(Tester.StoreId!, p2PPosSettings.FormId);
         Assert.NotNull(formData);
         var form = Form.Parse(formData!.Config);
-        var depixAddressField = form.GetFieldByFullName("depixAddress");
-        Assert.NotNull(depixAddressField);
-        Assert.True(depixAddressField!.Required);
+        AssertRequiredP2PFields(form);
     }
 
     [Fact(Timeout = TestUtils.TestTimeout)]
@@ -249,9 +245,7 @@ public class PixSettingsTests : PlaywrightBaseTest
         var forms = await formDataService.GetForms(Tester.StoreId!);
         var repairedForm = Assert.Single(forms, form => form.Name == "DePix P2P checkout");
         var parsedForm = Form.Parse(repairedForm.Config);
-        var depixAddressField = parsedForm.GetFieldByFullName("depixAddress");
-        Assert.NotNull(depixAddressField);
-        Assert.True(depixAddressField!.Required);
+        AssertRequiredP2PFields(parsedForm);
         Assert.NotNull(parsedForm.GetFieldByFullName("customerNote"));
 
         var apps = (await appService.GetApps(PointOfSaleAppType.AppType))
@@ -284,5 +278,16 @@ public class PixSettingsTests : PlaywrightBaseTest
         Assert.True(storeConfig!.IsEnabled);
         Assert.Null(storeConfig.EncryptedApiKey);
         Assert.Null(storeConfig.WebhookSecretHashHex);
+    }
+
+    private static void AssertRequiredP2PFields(Form form)
+    {
+        var depixAddressField = form.GetFieldByFullName("depixAddress");
+        Assert.NotNull(depixAddressField);
+        Assert.True(depixAddressField!.Required);
+
+        var taxNumberField = form.GetFieldByFullName("endUserTaxNumber");
+        Assert.NotNull(taxNumberField);
+        Assert.True(taxNumberField!.Required);
     }
 }

--- a/BTCPayServer.Plugins.Depix.Tests/PixSettingsTests.cs
+++ b/BTCPayServer.Plugins.Depix.Tests/PixSettingsTests.cs
@@ -47,12 +47,14 @@ public class PixSettingsTests : PlaywrightBaseTest
         await Page.Locator("#UseWhitelist").SetCheckedAsync(true);
         await Page.GetByRole(AriaRole.Button, new() { Name = "Save" }).ClickAsync();
 
-        await Tester.FindAlertMessage(partialText: "Pix configuration applied");
+        await Tester.FindAlertMessage(partialText: "DePix payer identification form was created");
 
         Assert.True(await Page.Locator("#IsEnabled").IsCheckedAsync());
         await Page.GetByText("Payment options").ClickAsync();
         Assert.True(await Page.Locator("#PassFeeToCustomer").IsCheckedAsync());
         Assert.True(await Page.Locator("#UseWhitelist").IsCheckedAsync());
+        await AssertPixIdentificationFormReady();
+        await AssertNoPointOfSaleAppsCreated();
     }
 
     [Fact(Timeout = TestUtils.TestTimeout)]
@@ -146,6 +148,49 @@ public class PixSettingsTests : PlaywrightBaseTest
         Assert.Equal("5%", storeConfig.P2PCommissionPercent);
         Assert.Null(storeConfig.SplitFee);
         Assert.Null(storeConfig.DepixSplitAddress);
+    }
+
+    [Fact(Timeout = TestUtils.TestTimeout)]
+    [Trait("Category", "PlaywrightUITest")]
+    public async Task DoesNotCreatePixIdentificationFormWhenCompatibleFormExists()
+    {
+        await InitializeStoreOwnerAsync();
+        await SeedValidStorePixConfigAsync();
+
+        var formDataService = Server.PayTester.GetService<FormDataService>();
+        var compatibleForm = new Form();
+        compatibleForm.Fields.Add(Field.Create(
+            "Customer note",
+            "customerNote",
+            null,
+            false,
+            "Optional note."));
+        compatibleForm.Fields.Add(Field.Create(
+            "CPF/CNPJ",
+            "endUserTaxNumber",
+            null,
+            true,
+            "CPF/CNPJ of the Pix payer."));
+        var compatibleFormData = new FormData
+        {
+            StoreId = Tester.StoreId!,
+            Name = "Existing checkout",
+            Config = compatibleForm.ToString()
+        };
+        await formDataService.AddOrUpdateForm(compatibleFormData);
+
+        await GoToPixSettingsAsync();
+
+        await Page.Locator("#IsEnabled").SetCheckedAsync(true);
+        await Page.GetByRole(AriaRole.Button, new() { Name = "Save" }).ClickAsync();
+
+        await Tester.FindAlertMessage(partialText: "Pix configuration applied");
+
+        var forms = await formDataService.GetForms(Tester.StoreId!);
+        Assert.DoesNotContain(forms, form => form.Name == "DePix payer identification");
+        var existingForm = Assert.Single(forms, form => form.Name == "Existing checkout");
+        AssertRequiredPayerTaxNumberField(Form.Parse(existingForm.Config));
+        await AssertNoPointOfSaleAppsCreated();
     }
 
     [Fact(Timeout = TestUtils.TestTimeout)]
@@ -257,6 +302,44 @@ public class PixSettingsTests : PlaywrightBaseTest
 
     [Fact(Timeout = TestUtils.TestTimeout)]
     [Trait("Category", "PlaywrightUITest")]
+    public async Task RepairsExistingPixIdentificationForm()
+    {
+        await InitializeStoreOwnerAsync();
+        await SeedValidStorePixConfigAsync();
+
+        var formDataService = Server.PayTester.GetService<FormDataService>();
+        var customForm = new Form();
+        customForm.Fields.Add(Field.Create(
+            "Customer note",
+            "customerNote",
+            null,
+            false,
+            "Optional note."));
+        var brokenForm = new FormData
+        {
+            StoreId = Tester.StoreId!,
+            Name = "DePix payer identification",
+            Config = customForm.ToString()
+        };
+        await formDataService.AddOrUpdateForm(brokenForm);
+
+        await GoToPixSettingsAsync();
+
+        await Page.Locator("#IsEnabled").SetCheckedAsync(true);
+        await Page.GetByRole(AriaRole.Button, new() { Name = "Save" }).ClickAsync();
+
+        await Tester.FindAlertMessage(partialText: "DePix payer identification form was updated");
+
+        var forms = await formDataService.GetForms(Tester.StoreId!);
+        var repairedForm = Assert.Single(forms, form => form.Name == "DePix payer identification");
+        var parsedForm = Form.Parse(repairedForm.Config);
+        AssertRequiredPayerTaxNumberField(parsedForm);
+        Assert.NotNull(parsedForm.GetFieldByFullName("customerNote"));
+        await AssertNoPointOfSaleAppsCreated();
+    }
+
+    [Fact(Timeout = TestUtils.TestTimeout)]
+    [Trait("Category", "PlaywrightUITest")]
     public async Task CanEnablePixUsingServerLevelConfiguration()
     {
         await InitializeStoreOwnerAsync();
@@ -278,6 +361,26 @@ public class PixSettingsTests : PlaywrightBaseTest
         Assert.True(storeConfig!.IsEnabled);
         Assert.Null(storeConfig.EncryptedApiKey);
         Assert.Null(storeConfig.WebhookSecretHashHex);
+        await AssertPixIdentificationFormReady();
+        await AssertNoPointOfSaleAppsCreated();
+    }
+
+    private async Task AssertPixIdentificationFormReady()
+    {
+        var formDataService = Server.PayTester.GetService<FormDataService>();
+        var forms = await formDataService.GetForms(Tester.StoreId!);
+        var formData = Assert.Single(forms, form => form.Name == "DePix payer identification");
+        var form = Form.Parse(formData.Config);
+        AssertRequiredPayerTaxNumberField(form);
+    }
+
+    private async Task AssertNoPointOfSaleAppsCreated()
+    {
+        var appService = Server.PayTester.GetService<AppService>();
+        var apps = (await appService.GetApps(PointOfSaleAppType.AppType))
+            .Where(app => app.StoreDataId == Tester.StoreId)
+            .ToList();
+        Assert.Empty(apps);
     }
 
     private static void AssertRequiredP2PFields(Form form)
@@ -286,6 +389,11 @@ public class PixSettingsTests : PlaywrightBaseTest
         Assert.NotNull(depixAddressField);
         Assert.True(depixAddressField!.Required);
 
+        AssertRequiredPayerTaxNumberField(form);
+    }
+
+    private static void AssertRequiredPayerTaxNumberField(Form form)
+    {
         var taxNumberField = form.GetFieldByFullName("endUserTaxNumber");
         Assert.NotNull(taxNumberField);
         Assert.True(taxNumberField!.Required);

--- a/BTCPayServer.Plugins.Depix/BTCPayServer.Plugins.Depix.csproj
+++ b/BTCPayServer.Plugins.Depix/BTCPayServer.Plugins.Depix.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <Product>Decentralized Pix Liquid Integration</Product>
     <Description>Enables store owners to accept Pix payments automatically converted to Liquid stablecoins using DePix.</Description>
-    <Version>1.0.6</Version>
+    <Version>1.0.7</Version>
   </PropertyGroup>
 
 

--- a/BTCPayServer.Plugins.Depix/Controllers/PixController.cs
+++ b/BTCPayServer.Plugins.Depix/Controllers/PixController.cs
@@ -38,7 +38,8 @@ public class PixController(
     : Controller
 {
     private const string P2PDepixAddressFieldName = "depixAddress";
-    private const string P2PEndUserTaxNumberFieldName = "endUserTaxNumber";
+    private const string EndUserTaxNumberFieldName = "endUserTaxNumber";
+    private const string PixIdentificationFormName = "DePix payer identification";
     private const string P2PDefaultFormName = "DePix P2P checkout";
     private const string P2PDefaultPosName = "DePix P2P";
     private StoreData StoreData => HttpContext.GetStoreData();
@@ -220,6 +221,9 @@ public class PixController(
 
         await storeRepository.UpdateStore(store);
 
+        var pixFormSetup = willEnable
+            ? await EnsurePixIdentificationFormAsync(store.Id)
+            : null;
         var p2PPosSetup = viewModel.P2PMode
             ? await EnsureP2PPointOfSaleAsync(store.Id)
             : null;
@@ -227,14 +231,57 @@ public class PixController(
         if (!string.IsNullOrEmpty(oneShotSecretToDisplay))
             TempData["OneShotSecret"] = oneShotSecretToDisplay;
 
-        TempData[WellKnownTempData.SuccessMessage] = p2PPosSetup is { PosAppCreated: true }
-            ? "Pix configuration applied. DePix P2P POS app was created."
-            : p2PPosSetup is { PosAppUpdated: true }
-                ? "Pix configuration applied. DePix P2P POS app was updated."
-            : viewModel.P2PMode
-                ? "Pix configuration applied. DePix P2P POS app is ready."
-                : "Pix configuration applied";
+        var successMessage = "Pix configuration applied.";
+        if (pixFormSetup is { FormCreated: true })
+            successMessage += " DePix payer identification form was created.";
+        else if (pixFormSetup is { FormUpdated: true })
+            successMessage += " DePix payer identification form was updated.";
+
+        if (p2PPosSetup is { PosAppCreated: true })
+            successMessage += " DePix P2P POS app was created.";
+        else if (p2PPosSetup is { PosAppUpdated: true })
+            successMessage += " DePix P2P POS app was updated.";
+        else if (viewModel.P2PMode)
+            successMessage += " DePix P2P POS app is ready.";
+
+        TempData[WellKnownTempData.SuccessMessage] = successMessage;
         return RedirectToAction(nameof(PixSettings), new { storeId = StoreData.Id, walletId });
+    }
+
+    private async Task<PixFormSetupResult> EnsurePixIdentificationFormAsync(string storeId)
+    {
+        var forms = await formDataService.GetForms(storeId);
+        var existing = forms.FirstOrDefault(form => string.Equals(form.Name, PixIdentificationFormName, StringComparison.Ordinal));
+        if (existing is not null)
+        {
+            if (FormDataHasRequiredPayerTaxNumberField(existing))
+                return new PixFormSetupResult(false, false);
+
+            if (TryParseForm(existing, out var form))
+            {
+                EnsurePayerTaxNumberField(form);
+                existing.Config = form.ToString();
+            }
+            else
+            {
+                existing.Config = CreatePixIdentificationForm().ToString();
+            }
+
+            await formDataService.AddOrUpdateForm(existing);
+            return new PixFormSetupResult(false, true);
+        }
+
+        if (forms.Any(FormDataHasRequiredPayerTaxNumberField))
+            return new PixFormSetupResult(false, false);
+
+        var formData = new FormData
+        {
+            StoreId = storeId,
+            Name = PixIdentificationFormName,
+            Config = CreatePixIdentificationForm().ToString()
+        };
+        await formDataService.AddOrUpdateForm(formData);
+        return new PixFormSetupResult(true, false);
     }
 
     private async Task<P2PPosSetupResult> EnsureP2PPointOfSaleAsync(string storeId)
@@ -320,7 +367,13 @@ public class PixController(
     {
         return TryParseForm(formData, out var form) &&
                form.GetFieldByFullName(P2PDepixAddressFieldName) is { Required: true } &&
-               form.GetFieldByFullName(P2PEndUserTaxNumberFieldName) is { Required: true };
+               form.GetFieldByFullName(EndUserTaxNumberFieldName) is { Required: true };
+    }
+
+    private static bool FormDataHasRequiredPayerTaxNumberField(FormData? formData)
+    {
+        return TryParseForm(formData, out var form) &&
+               form.GetFieldByFullName(EndUserTaxNumberFieldName) is { Required: true };
     }
 
     private static bool TryParseForm(FormData? formData, out Form form)
@@ -347,6 +400,13 @@ public class PixController(
         return form;
     }
 
+    private static Form CreatePixIdentificationForm()
+    {
+        var form = new Form();
+        EnsurePayerTaxNumberField(form);
+        return form;
+    }
+
     private static void EnsureP2PFields(Form form)
     {
         EnsureRequiredField(
@@ -357,8 +417,17 @@ public class PixController(
         EnsureRequiredField(
             form,
             "CPF/CNPJ",
-            P2PEndUserTaxNumberFieldName,
+            EndUserTaxNumberFieldName,
             "CPF/CNPJ of the Pix payer.");
+    }
+
+    private static void EnsurePayerTaxNumberField(Form form)
+    {
+        EnsureRequiredField(
+            form,
+            "CPF/CNPJ",
+            EndUserTaxNumberFieldName,
+            "CPF/CNPJ of the Pix payer. Send as text to preserve leading zeros.");
     }
 
     private static void EnsureRequiredField(Form form, string label, string name, string helpText)
@@ -373,6 +442,7 @@ public class PixController(
         form.Fields.Add(Field.Create(label, name, null, true, helpText));
     }
 
+    private sealed record PixFormSetupResult(bool FormCreated, bool FormUpdated);
     private sealed record P2PPosSetupResult(string FormId, bool PosAppCreated, bool PosAppUpdated);
 
     /// <summary>

--- a/BTCPayServer.Plugins.Depix/Controllers/PixController.cs
+++ b/BTCPayServer.Plugins.Depix/Controllers/PixController.cs
@@ -38,6 +38,7 @@ public class PixController(
     : Controller
 {
     private const string P2PDepixAddressFieldName = "depixAddress";
+    private const string P2PEndUserTaxNumberFieldName = "endUserTaxNumber";
     private const string P2PDefaultFormName = "DePix P2P checkout";
     private const string P2PDefaultPosName = "DePix P2P";
     private StoreData StoreData => HttpContext.GetStoreData();
@@ -291,19 +292,17 @@ public class PixController(
         var existing = forms.FirstOrDefault(form => string.Equals(form.Name, P2PDefaultFormName, StringComparison.Ordinal));
         if (existing is not null)
         {
-            if (!FormDataHasP2PAddressField(existing))
+            if (FormDataHasRequiredP2PFields(existing)) return existing.Id;
+            if (TryParseForm(existing, out var form))
             {
-                if (TryParseForm(existing, out var form))
-                {
-                    EnsureP2PAddressField(form);
-                    existing.Config = form.ToString();
-                }
-                else
-                {
-                    existing.Config = CreateP2PAddressForm().ToString();
-                }
-                await formDataService.AddOrUpdateForm(existing);
+                EnsureP2PFields(form);
+                existing.Config = form.ToString();
             }
+            else
+            {
+                existing.Config = CreateP2PForm().ToString();
+            }
+            await formDataService.AddOrUpdateForm(existing);
             return existing.Id;
         }
 
@@ -311,16 +310,17 @@ public class PixController(
         {
             StoreId = storeId,
             Name = P2PDefaultFormName,
-            Config = CreateP2PAddressForm().ToString()
+            Config = CreateP2PForm().ToString()
         };
         await formDataService.AddOrUpdateForm(formData);
         return formData.Id;
     }
 
-    private static bool FormDataHasP2PAddressField(FormData? formData)
+    private static bool FormDataHasRequiredP2PFields(FormData? formData)
     {
         return TryParseForm(formData, out var form) &&
-               form.GetFieldByFullName(P2PDepixAddressFieldName) is { Required: true };
+               form.GetFieldByFullName(P2PDepixAddressFieldName) is { Required: true } &&
+               form.GetFieldByFullName(P2PEndUserTaxNumberFieldName) is { Required: true };
     }
 
     private static bool TryParseForm(FormData? formData, out Form form)
@@ -340,24 +340,37 @@ public class PixController(
         }
     }
 
-    private static Form CreateP2PAddressForm()
+    private static Form CreateP2PForm()
     {
         var form = new Form();
-        EnsureP2PAddressField(form);
+        EnsureP2PFields(form);
         return form;
     }
 
-    private static void EnsureP2PAddressField(Form form)
+    private static void EnsureP2PFields(Form form)
     {
-        if (form.GetFieldByFullName(P2PDepixAddressFieldName) is not null)
-            return;
-
-        form.Fields.Add(Field.Create(
+        EnsureRequiredField(
+            form,
             "DePix address",
             P2PDepixAddressFieldName,
-            null,
-            true,
-            "Buyer Liquid/DePix address that receives the purchased DePix."));
+            "Buyer Liquid/DePix address that receives the purchased DePix.");
+        EnsureRequiredField(
+            form,
+            "CPF/CNPJ",
+            P2PEndUserTaxNumberFieldName,
+            "CPF/CNPJ of the Pix payer.");
+    }
+
+    private static void EnsureRequiredField(Form form, string label, string name, string helpText)
+    {
+        var existing = form.GetFieldByFullName(name);
+        if (existing is not null)
+        {
+            existing.Required = true;
+            return;
+        }
+
+        form.Fields.Add(Field.Create(label, name, null, true, helpText));
     }
 
     private sealed record P2PPosSetupResult(string FormId, bool PosAppCreated, bool PosAppUpdated);

--- a/BTCPayServer.Plugins.Depix/PaymentHandlers/PixPaymentMethodHandler.cs
+++ b/BTCPayServer.Plugins.Depix/PaymentHandlers/PixPaymentMethodHandler.cs
@@ -82,13 +82,13 @@ public class PixPaymentMethodHandler(
         using var client = depixService.CreateDepixClient(apiKey);
 
         var metadata = context.InvoiceEntity.Metadata?.AdditionalData;
-        var formResponse = GetCurrentFormResponse();
-        var endUserTaxNumber = ResolvePayerTaxNumber(metadata, formResponse);
+        var formValues = TryParseFormResponse(GetCurrentFormResponse());
+        var endUserTaxNumber = ResolvePayerTaxNumber(metadata, formValues);
 
         string? p2PDestinationAddress = null;
         var p2PMode = pixCfg.P2PMode && TryGetP2PDestinationAddress(
             metadata,
-            metadata?.ContainsKey(P2PDepixAddressMetadataKey) is true ? null : formResponse,
+            metadata?.ContainsKey(P2PDepixAddressMetadataKey) is true ? null : formValues,
             out p2PDestinationAddress);
         string address;
 
@@ -130,24 +130,15 @@ public class PixPaymentMethodHandler(
         depixService.ApplyPromptDetails(context, deposit, address, amountInCents, p2PMode, depixSplitAddress, p2PCommissionPercent);
     }
 
-    private bool TryGetP2PDestinationAddress(PaymentMethodContext context, out string? address)
-    {
-        var metadata = context.InvoiceEntity.Metadata?.AdditionalData;
-        return TryGetP2PDestinationAddress(
-            metadata,
-            metadata?.ContainsKey(P2PDepixAddressMetadataKey) is true ? null : GetCurrentFormResponse(),
-            out address);
-    }
-
     private static bool TryGetP2PDestinationAddress(
         IDictionary<string, JToken>? metadata,
-        string? formResponse,
+        JObject? formValues,
         out string? address)
     {
         address = null;
         var token = metadata is not null && metadata.TryGetValue(P2PDepixAddressMetadataKey, out var value)
             ? value
-            : TryGetP2PDestinationAddressFromFormResponse(formResponse);
+            : formValues?.GetValue(P2PDepixAddressMetadataKey);
 
         if (token is null)
             return false;
@@ -176,29 +167,12 @@ public class PixPaymentMethodHandler(
             : null;
     }
 
-    private static JToken? TryGetP2PDestinationAddressFromFormResponse(string? formResponse)
-    {
-        if (string.IsNullOrWhiteSpace(formResponse))
-            return null;
-
-        try
-        {
-            var values = JObject.Parse(formResponse);
-            return values.TryGetValue(P2PDepixAddressMetadataKey, out var token) ? token : null;
-        }
-        catch (JsonReaderException)
-        {
-            return null;
-        }
-    }
-
     private static string ResolvePayerTaxNumber(
         IDictionary<string, JToken>? metadata,
-        string? formResponse)
+        JObject? formValues)
     {
-        var formValues = TryParseFormResponse(formResponse);
         var taxNumber = TryGetString(metadata, EndUserTaxNumberMetadataKey) ??
-                        TryGetString(formValues, EndUserTaxNumberMetadataKey);
+                        TryGetString(formValues?.GetValue(EndUserTaxNumberMetadataKey));
 
         if (string.IsNullOrWhiteSpace(taxNumber))
         {
@@ -226,16 +200,15 @@ public class PixPaymentMethodHandler(
 
     private static string? TryGetString(IDictionary<string, JToken>? values, string key)
     {
-        if (values is null || !values.TryGetValue(key, out var token) || token.Type != JTokenType.String)
+        if (values is null || !values.TryGetValue(key, out var token))
             return null;
 
-        var value = token.Value<string>()?.Trim();
-        return string.IsNullOrWhiteSpace(value) ? null : value;
+        return TryGetString(token);
     }
 
-    private static string? TryGetString(JObject? values, string key)
+    private static string? TryGetString(JToken? token)
     {
-        if (values is null || !values.TryGetValue(key, out var token) || token.Type != JTokenType.String)
+        if (token?.Type != JTokenType.String)
             return null;
 
         var value = token.Value<string>()?.Trim();

--- a/BTCPayServer.Plugins.Depix/PaymentHandlers/PixPaymentMethodHandler.cs
+++ b/BTCPayServer.Plugins.Depix/PaymentHandlers/PixPaymentMethodHandler.cs
@@ -203,7 +203,7 @@ public class PixPaymentMethodHandler(
         if (string.IsNullOrWhiteSpace(taxNumber))
         {
             throw new PaymentMethodUnavailableException(
-                "Pix requires payer CPF/CNPJ. Provide endUserTaxNumber.");
+                "Pix requires payer CPF/CNPJ in invoice metadata or POS form field endUserTaxNumber. Send it as a string.");
         }
 
         return taxNumber.Trim();

--- a/BTCPayServer.Plugins.Depix/PaymentHandlers/PixPaymentMethodHandler.cs
+++ b/BTCPayServer.Plugins.Depix/PaymentHandlers/PixPaymentMethodHandler.cs
@@ -27,6 +27,7 @@ public class PixPaymentMethodHandler(
     : IPaymentMethodHandler, IHasNetwork
 {
     private const string P2PDepixAddressMetadataKey = "depixAddress";
+    private const string EndUserTaxNumberMetadataKey = "endUserTaxNumber";
 
     /// <summary>
     /// The payment method ID for Pix
@@ -80,8 +81,15 @@ public class PixPaymentMethodHandler(
 
         using var client = depixService.CreateDepixClient(apiKey);
 
+        var metadata = context.InvoiceEntity.Metadata?.AdditionalData;
+        var formResponse = GetCurrentFormResponse();
+        var endUserTaxNumber = ResolvePayerTaxNumber(metadata, formResponse);
+
         string? p2PDestinationAddress = null;
-        var p2PMode = pixCfg.P2PMode && TryGetP2PDestinationAddress(context, out p2PDestinationAddress);
+        var p2PMode = pixCfg.P2PMode && TryGetP2PDestinationAddress(
+            metadata,
+            metadata?.ContainsKey(P2PDepixAddressMetadataKey) is true ? null : formResponse,
+            out p2PDestinationAddress);
         string address;
 
         string? depixSplitAddress = null;
@@ -114,6 +122,7 @@ public class PixPaymentMethodHandler(
             address, 
             pixCfg,
             effectiveConfig.UseWhitelist,
+            endUserTaxNumber,
             CancellationToken.None,
             depixSplitAddress,
             p2PCommissionPercent);
@@ -181,6 +190,56 @@ public class PixPaymentMethodHandler(
         {
             return null;
         }
+    }
+
+    private static string ResolvePayerTaxNumber(
+        IDictionary<string, JToken>? metadata,
+        string? formResponse)
+    {
+        var formValues = TryParseFormResponse(formResponse);
+        var taxNumber = TryGetString(metadata, EndUserTaxNumberMetadataKey) ??
+                        TryGetString(formValues, EndUserTaxNumberMetadataKey);
+
+        if (string.IsNullOrWhiteSpace(taxNumber))
+        {
+            throw new PaymentMethodUnavailableException(
+                "Pix requires payer CPF/CNPJ. Provide endUserTaxNumber.");
+        }
+
+        return taxNumber.Trim();
+    }
+
+    private static JObject? TryParseFormResponse(string? formResponse)
+    {
+        if (string.IsNullOrWhiteSpace(formResponse))
+            return null;
+
+        try
+        {
+            return JObject.Parse(formResponse);
+        }
+        catch (JsonReaderException)
+        {
+            return null;
+        }
+    }
+
+    private static string? TryGetString(IDictionary<string, JToken>? values, string key)
+    {
+        if (values is null || !values.TryGetValue(key, out var token) || token.Type != JTokenType.String)
+            return null;
+
+        var value = token.Value<string>()?.Trim();
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    private static string? TryGetString(JObject? values, string key)
+    {
+        if (values is null || !values.TryGetValue(key, out var token) || token.Type != JTokenType.String)
+            return null;
+
+        var value = token.Value<string>()?.Trim();
+        return string.IsNullOrWhiteSpace(value) ? null : value;
     }
 
     /// <summary>

--- a/BTCPayServer.Plugins.Depix/Services/DepixService.cs
+++ b/BTCPayServer.Plugins.Depix/Services/DepixService.cs
@@ -26,7 +26,6 @@ using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Rates;
 using BTCPayServer.Services.Stores;
 using BTCPayServer.Services.Wallets;
-using BTCPayServer;
 using Dapper;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -282,14 +281,20 @@ public class DepixService(
         string depixAddress,
         PixPaymentMethodConfig pixCfg,
         bool useWhitelist,
+        string endUserTaxNumber,
         CancellationToken ct,
         string? depixSplitAddressOverride = null,
         string? splitFeeOverride = null)
     {
+        endUserTaxNumber = endUserTaxNumber.Trim();
+        if (string.IsNullOrWhiteSpace(endUserTaxNumber))
+            throw new PaymentMethodUnavailableException("Pix requires payer CPF/CNPJ.");
+
         var payload = new Dictionary<string, object>
         {
             ["amountInCents"] = amountInCents,
-            ["depixAddress"]  = depixAddress
+            ["depixAddress"]  = depixAddress,
+            ["endUserTaxNumber"] = endUserTaxNumber
         };
         
         if (useWhitelist)

--- a/BTCPayServer.Plugins.Depix/Services/DepixService.cs
+++ b/BTCPayServer.Plugins.Depix/Services/DepixService.cs
@@ -286,9 +286,7 @@ public class DepixService(
         string? depixSplitAddressOverride = null,
         string? splitFeeOverride = null)
     {
-        endUserTaxNumber = endUserTaxNumber.Trim();
-        if (string.IsNullOrWhiteSpace(endUserTaxNumber))
-            throw new PaymentMethodUnavailableException("Pix requires payer CPF/CNPJ.");
+        endUserTaxNumber = NormalizeEndUserTaxNumber(endUserTaxNumber);
 
         var payload = new Dictionary<string, object>
         {
@@ -350,6 +348,21 @@ public class DepixService(
             throw new PaymentMethodUnavailableException("DePix response did not include qrCopyPaste");
 
         return new DepixDepositResponse(qrId, qrImageUrl!, copyPaste!);
+    }
+
+    private static string NormalizeEndUserTaxNumber(string endUserTaxNumber)
+    {
+        var digits = new StringBuilder(endUserTaxNumber.Length);
+        foreach (var c in endUserTaxNumber)
+        {
+            if (c >= '0' && c <= '9')
+                digits.Append(c);
+        }
+
+        if (digits.Length == 0)
+            throw new PaymentMethodUnavailableException("Pix requires payer CPF/CNPJ.");
+
+        return digits.ToString();
     }
     
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Send CPF/CNPJ as a JSON string, not a number, because valid CPF/CNPJ values can 
 }
 ```
 
+Formatted values such as `012.345.678-90` and `12.345.678/0001-95` are accepted. The plugin removes the mask and sends only digits to Eulen.
+
 Pix will be unavailable for an invoice if `endUserTaxNumber` is missing, blank, or sent as a JSON number.
 
 See [Checkout Requirements](docs/checkout-requirements.md) for invoice, API, and POS behavior.

--- a/README.md
+++ b/README.md
@@ -1,220 +1,83 @@
 # DePix Plugin for BTCPay Server
 
-Accept **Pix** payments in your BTCPay Server store and receive funds in **DePix** (a Liquid-based BRL stablecoin). This guide is written for BTCPay store owners and server admins and focuses on setup and day-to-day use.
+Accept **Pix** payments in your BTCPay Server store and receive funds in **DePix**, a Liquid-based BRL stablecoin.
 
----
+> Community plugin. Not affiliated with BTCPay Server or DePix. Treat it as experimental for now. Feedback is welcome.
 
-## What it does
+## What It Does
 
-* Adds Liquid Network Stablecoin **DePix** as a payment method to your BTCPay store.
-* Adds **Pix** as a payment method to your BTCPay store (via DePix).
-* After you save a valid DePix configuration, Pix can be enabled and appears on newly created invoices (from **Invoices**) and in your **Point of Sale (POS)** apps.
+* Adds Liquid Network Stablecoin **DePix** as a payment method.
+* Adds **Pix** as a payment method through DePix.
+* Creates Pix deposit QR codes for compliant invoices and POS checkouts.
 * Provides a **Pix Transactions** page to monitor deposits and statuses.
-* Funds settle to your **DePix (Liquid) wallet**.
+* Settles funds to your **DePix (Liquid) wallet**.
 
-> Community plugin. Not affiliated with BTCPay Server or DePix. It’s new, so treat it as experimental for now. Feedback is welcome!
-
----
+![DePix plugin installed](docs/img/depix-plugin-installed.png)
 
 ## Requirements
 
 * BTCPay Server 2.x
-* A **DePix partner API key** — request at https://www.depix.info/#partners
+* A **DePix partner API key** from [depix.info](https://www.depix.info/#partners)
 
----
+## Quick Start
 
-## Installation
-
-1. Install the plugin in BTCPay (Plugins → Manage Plugins → search for DePix).
+1. Install the plugin in BTCPay: **Plugins -> Manage Plugins -> DePix**.
 2. Restart BTCPay when prompted.
+3. Create or connect your **DePix wallet**.
+4. Configure Pix in **Wallets -> Pix -> Settings**, or use server-wide configuration from **Server Settings -> Pix**.
+5. Register the webhook in the DePix Telegram bot using the command shown after saving settings.
+6. Make sure invoices and POS forms provide payer CPF/CNPJ as `endUserTaxNumber`.
 
-![DePix plugin installed](docs/img/depix-plugin-installed.png)
+Full setup details are in [Configuration](docs/configuration.md).
 
-> When installed, the DePix (Liquid) asset is prepared for your store. You only need to create your DePix wallet and configure DePix (store-level or server-level) to enable Pix payments.
+## Checkout Requirement
 
----
+Eulen requires every Pix deposit QR code to identify the payer. This plugin sends the payer CPF/CNPJ to `/deposit` as `endUserTaxNumber`.
 
-## Create your DePix wallet (choose one)
+Send CPF/CNPJ as a JSON string, not a number, because valid CPF/CNPJ values can start with `0`:
 
-### Option A — External (Aqua via SamRock Plugin, xpub import)
+```json
+{
+  "endUserTaxNumber": "01234567890"
+}
+```
 
-1) In BTCPay: Plugins → Manage Plugins → install **SamRock**; open SamRock and **scan** the pairing QR with the **Aqua** app.
-2) **Wallets** → **Liquid Bitcoin** → **Settings** → **Derivation Scheme** → **copy the LBTC xpub**.
-3) **Wallets → DePix → Connect an existing wallet → Enter extended public key** → paste the LBTC xpub → Continue.
+Pix will be unavailable for an invoice if `endUserTaxNumber` is missing, blank, or sent as a JSON number.
 
-Result: BTCPay derives Liquid/DePix receiving addresses from this xpub, so **deposits go directly to your Aqua wallet**.  
-(Only the **public** key is used; no private keys leave Aqua.)
+See [Checkout Requirements](docs/checkout-requirements.md) for invoice, API, and POS behavior.
 
-### Option B — BTCPay Hot Wallet
+## Documentation
 
-1) **Wallets → DePix → Create new wallet → Hot wallet**.
-2) To spend from your own Elements/Liquid node later, import the generated keys using **Liquid+** and `elements-cli` (see **Balance and spending DePix**).
+* [Configuration](docs/configuration.md): wallet setup, store/server settings, split payments, and webhook registration.
+* [Checkout Requirements](docs/checkout-requirements.md): Eulen compliance, `endUserTaxNumber`, invoices, API, and POS forms.
+* [P2P Mode](docs/p2p.md): selling DePix through the plugin-owned P2P POS.
+* [Spending DePix](docs/spending-depix.md): Aqua/SamRock, hot wallet, Liquid+, and `elements-cli`.
 
----
-
-## Configuration scopes (Store vs Server)
-
-DePix can be configured in one of two places:
-
-### Store configuration (recommended for most users)
-Path: **Wallets → Pix → Settings**
-
-Use this when:
-- You want store-specific behavior (fee/whitelist) and full control at store level, or
-- Your server admin did not configure DePix globally.
-
-### Server configuration (optional, for server admins)
-Path: **Server Settings → Pix (Pix Server Settings)**
-
-Use this when:
-- You run a BTCPay Server instance and want a **default configuration** for many stores with same API Key and Webhook.
-
-### Precedence (what gets used)
-- If the store has a complete **store configuration** (API key + webhook secret), **store config is used**.
-- Otherwise, if the server has a complete **server configuration**, **server config is used**.
-- If neither exists, Pix cannot be enabled.
-
-> When a store is using **server configuration**, the store does not manage webhook secrets. Webhook registration is handled by the server admin.
-
----
-
-## Store setup (Wallets → Pix → Settings)
-
-1. Go to **Wallets → Pix → Settings**
-2. Paste your **DePix API key** and click **Save**
-3. (Optional) Configure store behavior (only applies when the store has its own API key):
-   - **Pass fee to customer**
-   - **Whitelist mode**
-4. (Optional) Configure split payments:
-   - **DePix Split Address**: wallet that receives the split portion
-   - **Split Fee**: percentage of the Pix amount sent to the split address
-   - Both fields are required together; leave both empty to disable split
-5. (Optional) Enable **P2P mode** to sell DePix through POS/API:
-   - P2P invoices must include metadata field **`depixAddress`** with the buyer's DePix address.
-   - **P2P commission (%)** sets the seller commission percentage.
-   - The commission address is configured by the plugin P2P flow.
-   - A separate **DePix P2P** POS app and checkout form are created automatically.
-
-Example use cases for split payments:
-- **Merchant gateway**: you provide Pix via your Eulen API + BTCPay setup and charge a platform fee.
-- **Affiliates**: automatically send a commission to an affiliate wallet per sale.
-- **Coproduction**: split course sales between producer and coproducer wallets.
-- **Marketplace**: route a platform fee to your wallet while the seller receives the rest.
-- **Local partnerships**: split revenue between venue and service partner.
+## Screenshots
 
 ![Pix Settings](docs/img/pix-settings.png)
 
----
-
-## Server-wide setup (Server Settings → Pix)
-
-This is for BTCPay Server admins who want to configure DePix once and let stores inherit it.
-
-1. Go to **Server Settings → Pix (Pix Server Settings)**
-2. Paste the **server DePix API key** and click **Save**
-3. Configure defaults for stores that rely on server config:
-   - **Pass fee to customer**
-   - **Whitelist mode**
-
-![Pix Server Settings](docs/img/pix-server-settings.png)
-
----
-
-## Webhook registration (same flow for Store or Server)
-
-After you click **Save** (either in **store settings** or **server settings**), the page will show:
-
-- **Webhook URL**
-- **One-time secret**
-- A ready-to-copy **Telegram command**
-
-**Do this immediately:** copy the Telegram command **before refreshing or leaving the page**.  
-The secret is **one-time view**. If you miss it, you must **Regenerate secret** and click **Save** again.
-
-In the DePix Telegram bot (Eulen), run the command exactly as shown on the page.
-
-Notes:
-> Stores using server configuration do not have access to the server secret. The server admin should register the webhook.
-
----
-
-## Using it
-
-* **Invoices**: create an invoice as usual; customers will see **Pix** as a payment method.
-* **POS**: generate charges from your Point of Sale; Pix is available.
-* **P2P POS**: enable P2P mode in **Wallets → Pix → Settings** and set the seller commission in **P2P commission (%)**. The plugin creates a separate **DePix P2P** POS app with the required `depixAddress` form field, while existing POS apps can keep using normal Pix.
-
 ![Pix Invoice](docs/img/pix-invoice.png)
-
-* **Transactions**: go to **Wallets → Pix** to track Pix deposits (status, ID, amount, time, etc.).
-* **DePix Balance**: go to **Wallets → DePix** to track the received DePix converted from successful Pix transactions.
-
----
-
-## Balance and spending DePix
-
-After a Pix payment, funds settle to your **DePix (Liquid) wallet**.
-
-### Which setup are you using?
-
-- **SamRock + Aqua (xpub)**: funds go to your **Aqua wallet**. Spend them normally from Aqua — you **do not** need Liquid+ or `elements-cli`.
-- **BTCPay Hot Wallet**: follow the steps below to spend via your **Elements/Liquid node** (Liquid+).
-
----
-### Spend DePix from a BTCPay Hot Wallet (Liquid+ + elements-cli)
-1. Install the **Liquid+** plugin in BTCPay Server.
-2. Click on Liquid at the sidebar under the Store Settings.
-3. Use Liquid+ to run the key imports on your Elements/Liquid node:
-
-   * `importprivkey <WIF_PRIVATE_KEY>`
-   * `importblindingkey <ADDRESS> <BLINDING_KEY>`
-
-   > Import every address you plan to spend from. If you generated a new address in BTCPay, import its **privkey** and **blinding key**.
-4. **Rescan** the chain so the wallet finds past UTXOs belonging to those keys (faster if you know an approximate start height):
-
-   ```bash
-   elements-cli rescanblockchain 0
-   ```
-
-   You can pass a higher start height to speed things up, e.g. `rescanblockchain 120000`.
-5. **Verify your balance**:
-
-   ```bash
-   elements-cli getbalances
-   ```
-
-   (DePix Asset ID: 02f22f8d9c76ab41661a2729e4752e2c5d1a263012141b86ea98af5472df5189)
-6. **Send DePix** using `sendtoaddress` with the asset id that shown in getbalances as the last argument:
-
-   ```bash
-   elements-cli sendtoaddress "<DEST_LIQUID_ADDRESS>" <AMOUNT> "" "" false false null null null "<DEPix_ASSET_ID>"
-   ```
-
-   This constructs and broadcasts a confidential transaction of the specified **asset** (DePix) to the destination so you can swap for BTC.
-
-**Notes**
-
-* **Fees** are paid in **L-BTC** on Liquid. Keep a small L-BTC balance in the same wallet to cover network fees.
-
----
 
 ## FAQ
 
 **Where do I get the DePix API key?**
-At [https://www.depix.info/#partners](https://www.depix.info/#partners)
+
+Request one at [https://www.depix.info/#partners](https://www.depix.info/#partners).
 
 **Is the webhook mandatory?**
-No, but it’s **recommended** so you receive real‑time payment updates.
 
-**Pix doesn’t appear as a payment method. What should I check?**
-Make sure DePix is configured either in Wallets → Pix → Settings (store) or by the server admin in Server Settings → DePix (server). Once a complete configuration exists, Pix can be enabled and will appear on invoices/POS.
+No, but it is recommended so you receive real-time payment updates.
 
----
+**Pix does not appear as a payment method. What should I check?**
 
-## Support & feedback
+Make sure DePix is configured either at store level or server level. For each invoice, make sure payer CPF/CNPJ is available as a string in `endUserTaxNumber`.
 
-Open an **issue** on the repository with details of your problem or suggestion. Pull requests are welcome.
-For anything related to the DePix plugin, join [Telegram group](https://t.me/+xFiXWiZPAQ05O).
+## Support
+
+Open an issue with details of your problem or suggestion. Pull requests are welcome.
+
+For anything related to the DePix plugin, join the [Telegram group](https://t.me/+xFiXWiZPAQ05O).
 
 ## License
 

--- a/docs/checkout-requirements.md
+++ b/docs/checkout-requirements.md
@@ -1,0 +1,60 @@
+# Checkout Requirements
+
+Eulen requires every Pix deposit QR code to identify the payer. The plugin satisfies this by sending the payer CPF/CNPJ to `/deposit` as `endUserTaxNumber`.
+
+## Required Field
+
+Use the exact field name:
+
+```text
+endUserTaxNumber
+```
+
+The value must be a JSON string:
+
+```json
+{
+  "endUserTaxNumber": "01234567890"
+}
+```
+
+Do not send CPF/CNPJ as a JSON number. Valid CPF/CNPJ values can start with `0`, and numeric serialization can remove leading zeros.
+
+The plugin trims surrounding whitespace and sends the value unchanged after trimming. It does not normalize punctuation and does not validate CPF/CNPJ format locally. Eulen/Pix validates the value.
+
+The plugin does not require `endUserFullName` and does not send EUID.
+
+## Invoices And API
+
+For API-created or manually created invoices, include `endUserTaxNumber` in invoice metadata as a string:
+
+```json
+{
+  "metadata": {
+    "endUserTaxNumber": "01234567890"
+  }
+}
+```
+
+Pix will be unavailable for the invoice if the value is missing, blank, or sent as a JSON number.
+
+## POS Forms
+
+For regular POS checkouts, the invoice must include a form response with a required field named exactly `endUserTaxNumber`.
+
+When Pix is enabled, the plugin checks the store forms:
+
+* If any existing form already has required `endUserTaxNumber`, the plugin does not create another form.
+* If no compatible form exists, the plugin creates **DePix payer identification**.
+* If **DePix payer identification** already exists but is missing the required field, the plugin repairs that form.
+
+The plugin does not attach **DePix payer identification** to an existing POS automatically. Store owners can either attach that form to their POS or add a required `endUserTaxNumber` field to their existing checkout form.
+
+## Transactions And Balance
+
+After a compliant Pix payment is created, customers see Pix as a payment method on the invoice.
+
+* Go to **Wallets -> Pix** to track Pix deposits, status, ID, amount, and time.
+* Go to **Wallets -> DePix** to track received DePix after successful Pix transactions.
+
+![Pix Invoice](img/pix-invoice.png)

--- a/docs/checkout-requirements.md
+++ b/docs/checkout-requirements.md
@@ -20,7 +20,7 @@ The value must be a JSON string:
 
 Do not send CPF/CNPJ as a JSON number. Valid CPF/CNPJ values can start with `0`, and numeric serialization can remove leading zeros.
 
-The plugin trims surrounding whitespace and sends the value unchanged after trimming. It does not normalize punctuation and does not validate CPF/CNPJ format locally. Eulen/Pix validates the value.
+Formatted values such as `012.345.678-90` and `12.345.678/0001-95` are accepted. The plugin removes the mask and sends only digits to Eulen. It does not validate CPF/CNPJ format locally; Eulen/Pix validates the value.
 
 The plugin does not require `endUserFullName` and does not send EUID.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,97 @@
+# Configuration
+
+This page covers wallet setup, Pix configuration, split payments, and webhook registration.
+
+## Create Your DePix Wallet
+
+Choose one wallet setup before enabling Pix.
+
+### Option A: External Aqua Wallet Through SamRock
+
+1. In BTCPay, install **SamRock** from **Plugins -> Manage Plugins**.
+2. Open SamRock and scan the pairing QR with the **Aqua** app.
+3. Go to **Wallets -> Liquid Bitcoin -> Settings -> Derivation Scheme** and copy the LBTC xpub.
+4. Go to **Wallets -> DePix -> Connect an existing wallet -> Enter extended public key**.
+5. Paste the LBTC xpub and continue.
+
+BTCPay derives Liquid/DePix receiving addresses from this xpub, so deposits go directly to your Aqua wallet. Only the public key is used; no private keys leave Aqua.
+
+### Option B: BTCPay Hot Wallet
+
+1. Go to **Wallets -> DePix -> Create new wallet -> Hot wallet**.
+2. To spend from your own Elements/Liquid node later, import the generated keys using Liquid+ and `elements-cli`.
+
+See [Spending DePix](spending-depix.md) for the spending flow.
+
+## Configuration Scopes
+
+DePix can be configured at store level or server level.
+
+### Store Configuration
+
+Path: **Wallets -> Pix -> Settings**
+
+Use this when:
+
+* You want store-specific behavior such as fee and whitelist settings.
+* Your server admin did not configure DePix globally.
+
+### Server Configuration
+
+Path: **Server Settings -> Pix**
+
+Use this when you run a BTCPay Server instance and want a default DePix configuration for many stores.
+
+### Precedence
+
+* If the store has a complete store configuration, store configuration is used.
+* Otherwise, if the server has a complete server configuration, server configuration is used.
+* If neither exists, Pix cannot be enabled.
+
+When a store uses server configuration, the store does not manage webhook secrets. Webhook registration is handled by the server admin.
+
+## Store Setup
+
+1. Go to **Wallets -> Pix -> Settings**.
+2. Paste your **DePix API key** and click **Save**.
+3. Optionally configure store behavior:
+   * **Pass fee to customer**
+   * **Whitelist mode**
+4. Optionally configure split payments:
+   * **DePix Split Address**: wallet that receives the split portion.
+   * **Split Fee**: percentage of the Pix amount sent to the split address.
+   * Both fields are required together; leave both empty to disable split.
+
+![Pix Settings](img/pix-settings.png)
+
+## Split Payment Use Cases
+
+* **Merchant gateway**: provide Pix through your Eulen API and charge a platform fee.
+* **Affiliates**: automatically send a commission to an affiliate wallet per sale.
+* **Coproduction**: split course sales between producer and coproducer wallets.
+* **Marketplace**: route a platform fee to your wallet while the seller receives the rest.
+* **Local partnerships**: split revenue between venue and service partner.
+
+## Server-Wide Setup
+
+1. Go to **Server Settings -> Pix**.
+2. Paste the **server DePix API key** and click **Save**.
+3. Configure defaults for stores that rely on server configuration:
+   * **Pass fee to customer**
+   * **Whitelist mode**
+
+![Pix Server Settings](img/pix-server-settings.png)
+
+## Webhook Registration
+
+After you click **Save** in store settings or server settings, the page shows:
+
+* **Webhook URL**
+* **One-time secret**
+* A ready-to-copy **Telegram command**
+
+Copy the Telegram command before refreshing or leaving the page. The secret is shown only once. If you miss it, regenerate the secret and save again.
+
+In the DePix Telegram bot, run the command exactly as shown.
+
+Stores using server configuration do not have access to the server secret. The server admin should register the webhook.

--- a/docs/p2p.md
+++ b/docs/p2p.md
@@ -1,0 +1,36 @@
+# P2P Mode
+
+P2P mode is for stores that sell DePix. It is separate from normal merchant checkout flows where the store sells products or services.
+
+## Setup
+
+1. Go to **Wallets -> Pix -> Settings**.
+2. Enable **P2P mode**.
+3. Set **P2P commission (%)**.
+4. Save the settings.
+
+The plugin creates or repairs a separate POS app named **DePix P2P** with a checkout form named **DePix P2P checkout**.
+
+## Required Fields
+
+P2P invoices must identify both the DePix destination and the Pix payer:
+
+```json
+{
+  "depixAddress": "lq1...",
+  "endUserTaxNumber": "01234567890"
+}
+```
+
+Fields:
+
+* `depixAddress`: buyer's DePix address.
+* `endUserTaxNumber`: Pix payer CPF/CNPJ as a string.
+
+Do not send `endUserTaxNumber` as a JSON number because valid CPF/CNPJ values can start with `0`.
+
+## Existing POS Apps
+
+P2P mode does not modify regular POS apps. The plugin-owned **DePix P2P** POS is separate so stores can keep normal product sales and DePix sales apart.
+
+Existing normal POS apps can keep using Pix only if their invoice metadata or form response includes `endUserTaxNumber`.

--- a/docs/p2p.md
+++ b/docs/p2p.md
@@ -27,7 +27,7 @@ Fields:
 * `depixAddress`: buyer's DePix address.
 * `endUserTaxNumber`: Pix payer CPF/CNPJ as a string.
 
-Do not send `endUserTaxNumber` as a JSON number because valid CPF/CNPJ values can start with `0`.
+Do not send `endUserTaxNumber` as a JSON number because valid CPF/CNPJ values can start with `0`. Formatted values are accepted, but the plugin sends only digits to Eulen.
 
 ## Existing POS Apps
 

--- a/docs/spending-depix.md
+++ b/docs/spending-depix.md
@@ -1,0 +1,53 @@
+# Spending DePix
+
+After a Pix payment, funds settle to your **DePix (Liquid) wallet**.
+
+## Choose The Right Flow
+
+* **SamRock + Aqua xpub**: funds go to your Aqua wallet. Spend them normally from Aqua. You do not need Liquid+ or `elements-cli`.
+* **BTCPay Hot Wallet**: spend through your Elements/Liquid node using Liquid+ and `elements-cli`.
+
+## Spend From A BTCPay Hot Wallet
+
+1. Install the **Liquid+** plugin in BTCPay Server.
+2. Click **Liquid** in the store sidebar.
+3. Use Liquid+ to run the key imports on your Elements/Liquid node:
+
+   ```bash
+   importprivkey <WIF_PRIVATE_KEY>
+   importblindingkey <ADDRESS> <BLINDING_KEY>
+   ```
+
+   Import every address you plan to spend from. If you generated a new address in BTCPay, import its private key and blinding key.
+
+4. Rescan the chain so the wallet finds past UTXOs belonging to those keys:
+
+   ```bash
+   elements-cli rescanblockchain 0
+   ```
+
+   You can pass a higher start height to speed this up, for example `rescanblockchain 120000`.
+
+5. Verify your balance:
+
+   ```bash
+   elements-cli getbalances
+   ```
+
+   DePix Asset ID:
+
+   ```text
+   02f22f8d9c76ab41661a2729e4752e2c5d1a263012141b86ea98af5472df5189
+   ```
+
+6. Send DePix using `sendtoaddress` with the DePix asset ID as the last argument:
+
+   ```bash
+   elements-cli sendtoaddress "<DEST_LIQUID_ADDRESS>" <AMOUNT> "" "" false false null null null "<DEPIX_ASSET_ID>"
+   ```
+
+This constructs and broadcasts a confidential transaction for the DePix asset to the destination address.
+
+## Fees
+
+Liquid fees are paid in L-BTC. Keep a small L-BTC balance in the same wallet to cover network fees.


### PR DESCRIPTION
## Summary

Updates the DePix integration for Eulen's upcoming deposit identification requirement.

Eulen will require every deposit QR creation to identify the payer using either EUID or CPF/CNPJ. This plugin now uses CPF/CNPJ via `endUserTaxNumber` and sends it in the `/deposit` payload.

The generated DePix P2P POS form was also updated to collect the payer CPF/CNPJ.

## Notes

- Uses `endUserTaxNumber` only.
- Does not send `endUserFullName`, as Eulen clarified the full name is not required.
- Does not add EUID support in this patch.
- Does not add merchantId, delay, or withdraw changes.